### PR TITLE
写日志文件加锁

### DIFF
--- a/workerman/Core/Lib/Log.php
+++ b/workerman/Core/Lib/Log.php
@@ -75,7 +75,7 @@ class Log
         }
         
         $log_file = $log_dir . "/server.log";
-        file_put_contents($log_file, date('Y-m-d H:i:s') . " " . $msg . "\n", FILE_APPEND);
+        file_put_contents($log_file, date('Y-m-d H:i:s') . " " . $msg . "\n", FILE_APPEND|LOCK_EX);
     }
     
     /**


### PR DESCRIPTION
多进程写日志，加锁保证日志信息完整。