### PR TITLE
update worker  $_status

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -1250,6 +1250,9 @@ class Worker
      */
     public function run()
     {
+        //更新 Worker 状态
+        self::$_status = self::STATUS_RUNNING;
+        
         // 注册进程退出回调，用来检查是否有错误
         register_shutdown_function(array("\\Workerman\\Worker", 'checkErrors'));
         


### PR DESCRIPTION
多Worker情况下，守护进程启动后，Worker 进程的 `$_status` 属性一直处于 `STATUS_STARTING` 状态未更新。导致守护进程后 `log()` 方法直接输出到标准输出
。