### PR TITLE
fix phpdoc and removed unused variables etc.

### DIFF
--- a/Connection/AsyncTcpConnection.php
+++ b/Connection/AsyncTcpConnection.php
@@ -15,7 +15,7 @@ namespace Workerman\Connection;
 
 use Workerman\Events\EventInterface;
 use Workerman\Worker;
-use \Exception;
+use Exception;
 
 /**
  * AsyncTcpConnection.
@@ -37,8 +37,8 @@ class AsyncTcpConnection extends TcpConnection
     
     /**
      * Construct.
-     * @param resource $socket
-     * @param EventInterface $event
+     * @param string $remote_address
+     * @throws Exception
      */
     public function __construct($remote_address)
     {

--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -68,6 +68,8 @@ abstract class  ConnectionInterface
 
     /**
      * Close connection.
+     *
+     * @param $data
      * @return void
      */
     abstract public function close($data = null);

--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -15,7 +15,7 @@ namespace Workerman\Connection;
 
 use Workerman\Events\EventInterface;
 use Workerman\Worker;
-use \Exception;
+use Exception;
 
 /**
  * TcpConnection.
@@ -85,9 +85,9 @@ class TcpConnection extends ConnectionInterface
     /**
      * Application layer protocol.
      * The format is like this Workerman\\Protocols\\Http.
-     * @var string
+     * @var \Workerman\Protocols\ProtocolInterface
      */
-    public $protocol = '';
+    public $protocol = null;
     
     /**
      * Which worker belong to.
@@ -177,7 +177,7 @@ class TcpConnection extends ConnectionInterface
     /**
      * Construct.
      * @param resource $socket
-     * @param EventInterface $event
+     * @param string $remote_address
      */
     public function __construct($socket, $remote_address = '')
     {
@@ -194,7 +194,7 @@ class TcpConnection extends ConnectionInterface
      * Sends data on the connection.
      * @param string $send_buffer
      * @param bool $raw
-     * @return void|boolean
+     * @return void|bool|null
      */
     public function send($send_buffer, $raw = false)
     {
@@ -467,7 +467,7 @@ class TcpConnection extends ConnectionInterface
 
     /**
      * Base write handler.
-     * @return void
+     * @return void|bool
      */
     public function baseWrite()
     {
@@ -508,6 +508,7 @@ class TcpConnection extends ConnectionInterface
     
     /**
      * This method pulls all the data out of a readable stream, and writes it to the supplied destination.
+     * @param TcpConnection $dest
      * @return void
      */
     public function pipe($dest)
@@ -544,13 +545,13 @@ class TcpConnection extends ConnectionInterface
     /**
      * Close connection.
      * @param mixed $data
-     * @void
+     * @return void
      */
     public function close($data = null)
     {
         if($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED)
         {
-            return false;
+            return;
         }
         else
         {
@@ -606,7 +607,7 @@ class TcpConnection extends ConnectionInterface
         // Avoid repeated calls.
         if($this->_status === self::STATUS_CLOSED)
         {
-            return false;
+            return;
         }
         // Remove event listener.
         Worker::$globalEvent->del($this->_socket, EventInterface::EV_READ);

--- a/Connection/UdpConnection.php
+++ b/Connection/UdpConnection.php
@@ -21,9 +21,9 @@ class UdpConnection extends ConnectionInterface
     /**
      * Application layer protocol.
      * The format is like this Workerman\\Protocols\\Http.
-     * @var string
+     * @var \Workerman\Protocols\ProtocolInterface
      */
-    public $protocol = '';
+    public $protocol = null;
     
     /**
      * Udp socket.
@@ -63,6 +63,7 @@ class UdpConnection extends ConnectionInterface
     /**
      * Sends data on the connection.
      * @param string $send_buffer
+     * @param bool $raw
      * @return void|boolean
      */
     public function send($send_buffer, $raw = false)
@@ -107,7 +108,9 @@ class UdpConnection extends ConnectionInterface
 
     /**
      * Close connection.
-     * @void
+     *
+     * @param mixed $data
+     * @return bool
      */
     public function close($data = null)
     {

--- a/Events/Ev.php
+++ b/Events/Ev.php
@@ -44,7 +44,7 @@ class Ev implements EventInterface
 
     /**
      * Add a timer.
-     * @see EventInterface::add()
+     * {@inheritdoc}
      */
     public function add($fd, $flag, $func, $args=null)
     {
@@ -86,7 +86,7 @@ class Ev implements EventInterface
 
     /**
      * Remove a timer.
-     * @see Events\EventInterface::del()
+     * {@inheritdoc}
      */
     public function del($fd ,$flag)
     {
@@ -127,7 +127,7 @@ class Ev implements EventInterface
 
     /**
      * Timer callback.
-     * @param event $event
+     * @param \EvWatcher $event
      */
     public function timerCallback($event)
     {
@@ -171,5 +171,3 @@ class Ev implements EventInterface
         \Ev::run();
     }
 }
-
-

--- a/Events/EventInterface.php
+++ b/Events/EventInterface.php
@@ -47,16 +47,17 @@ interface EventInterface
     
     /**
      * Add event listener to event loop.
-     * @param resource $fd
+     * @param mixed $fd
      * @param int $flag
      * @param callable $func
+     * @param mixed $args
      * @return bool
      */
     public function add($fd, $flag, $func, $args = null);
     
     /**
      * Remove event listener from event loop.
-     * @param resource $fd
+     * @param mixed $fd
      * @param int $flag
      * @return bool
      */

--- a/Events/Libevent.php
+++ b/Events/Libevent.php
@@ -20,7 +20,7 @@ class Libevent implements EventInterface
 {
     /**
      * Event base.
-     * @var object
+     * @var resource
      */
     protected $_eventBase = null;
     
@@ -45,7 +45,6 @@ class Libevent implements EventInterface
     
     /**
      * construct
-     * @return void
      */
     public function __construct()
     {
@@ -53,7 +52,7 @@ class Libevent implements EventInterface
     }
    
     /**
-     * @see EventInterface::add()
+     * {@inheritdoc}
      */
     public function add($fd, $flag, $func, $args=array())
     {
@@ -127,7 +126,7 @@ class Libevent implements EventInterface
     }
     
     /**
-     * @see Events\EventInterface::del()
+     * {@inheritdoc}
      */
     public function del($fd ,$flag)
     {
@@ -169,9 +168,9 @@ class Libevent implements EventInterface
     
     /**
      * Timer callback.
-     * @param null $_null1
-     * @param null $_null2
-     * @param int $timer_id
+     * @param mixed $_null1
+     * @param int $_null2
+     * @param mixed $timer_id
      */
     protected function timerCallback($_null1, $_null2, $timer_id)
     {
@@ -195,8 +194,7 @@ class Libevent implements EventInterface
     }
     
     /**
-     * @see Events\EventInterface::clearAllTimer() 
-     * @return void
+     * {@inheritdoc}
      */
     public function clearAllTimer()
     {
@@ -207,9 +205,8 @@ class Libevent implements EventInterface
         $this->_eventTimer = array();
     }
      
-
     /**
-     * @see EventInterface::loop()
+     * {@inheritdoc}
      */
     public function loop()
     {

--- a/Events/Select.php
+++ b/Events/Select.php
@@ -45,7 +45,7 @@ class Select implements EventInterface
     /**
      * Timer scheduler.
      * {['data':timer_id, 'priority':run_timestamp], ..}
-     * @var SplPriorityQueue
+     * @var \SplPriorityQueue
      */
     protected $_scheduler = null;
     
@@ -67,10 +67,15 @@ class Select implements EventInterface
      * @var int
      */
     protected $_selectTimeout = 100000000;
+
+    /**
+     * Paired socket channels
+     * @var array
+     */
+    protected $channel = array();
     
     /**
      * Construct.
-     * @return void
      */
     public function __construct()
     {
@@ -87,7 +92,7 @@ class Select implements EventInterface
     }
     
     /**
-     * @see Events\EventInterface::add()
+     * {@inheritdoc}
      */
     public function add($fd, $flag, $func, $args = array())
     {
@@ -130,7 +135,7 @@ class Select implements EventInterface
     }
     
     /**
-     * @see Events\EventInterface::del()
+     * {@inheritdoc}
      */
     public function del($fd ,$flag)
     {
@@ -160,7 +165,7 @@ class Select implements EventInterface
                 unset($this->_task[$fd_key]);
                 return true;
         }
-        return false;;
+        return false;
     }
     
     /**
@@ -208,7 +213,7 @@ class Select implements EventInterface
     }
     
     /**
-     * @see Events\EventInterface::clearAllTimer()
+     * {@inheritdoc}
      */
     public function clearAllTimer()
     {
@@ -218,7 +223,7 @@ class Select implements EventInterface
     }
     
     /**
-     * @see Events\EventInterface::loop()
+     * {@inheritdoc}
      */
     public function loop()
     {

--- a/Lib/Timer.php
+++ b/Lib/Timer.php
@@ -12,8 +12,8 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Lib;
-use \Workerman\Events\EventInterface;
-use \Exception;
+use Workerman\Events\EventInterface;
+use Exception;
 
 /**
  * Timer.

--- a/Protocols/Frame.php
+++ b/Protocols/Frame.php
@@ -12,7 +12,7 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Protocols;
-use \Workerman\Connection\TcpConnection;
+use Workerman\Connection\TcpConnection;
 
 /**
  * Frame Protocol.
@@ -22,6 +22,8 @@ class Frame
     /**
      * Check the integrity of the package.
      * @param string $buffer
+     * @param TcpConnection $connection
+     * @return int
      */
     public static function input($buffer ,TcpConnection $connection)
     {

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -39,7 +39,7 @@ class Http
             return 0;
         }
         
-        list($header, $body) = explode("\r\n\r\n", $recv_buffer, 2);
+        list($header,) = explode("\r\n\r\n", $recv_buffer, 2);
         if(0 === strpos($recv_buffer, "POST"))
         {
             // find Content-Length
@@ -64,7 +64,7 @@ class Http
      * Parse $_POST、$_GET、$_COOKIE. 
      * @param string $recv_buffer
      * @param TcpConnection $connection
-     * @return void
+     * @return array
      */
     public static function decode($recv_buffer, TcpConnection $connection)
     {
@@ -98,7 +98,8 @@ class Http
         $header_data = explode("\r\n", $http_header);
         
         list($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['SERVER_PROTOCOL']) = explode(' ', $header_data[0]);
-        
+
+        $http_post_boundary = '';
         unset($header_data[0]);
         foreach($header_data as $content)
         {
@@ -260,7 +261,7 @@ class Http
     
     /**
      * 设置http头
-     * @return bool
+     * @return bool|void
      */
     public static function header($content, $replace = true, $http_response_code = 0)
     {
@@ -316,7 +317,8 @@ class Http
     {
         if(PHP_SAPI != 'cli')
         {
-            return header_remove($name);
+            header_remove($name);
+            return;
         }
         unset( HttpCache::$header[$name]);
     }
@@ -330,6 +332,7 @@ class Http
      * @param string $domain
      * @param bool $secure
      * @param bool $HTTPOnly
+     * @return bool|void
      */
     public static function setcookie($name, $value = '', $maxage = 0, $path = '', $domain = '', $secure = false, $HTTPOnly = false) {
         if(PHP_SAPI != 'cli')
@@ -446,6 +449,8 @@ class Http
     
      /**
      * Parse $_FILES.
+      * @param string $http_body
+      * @param string $http_post_boundary
      * @return void
      */
     protected static function parseUploadFiles($http_body, $http_post_boundary)
@@ -545,7 +550,12 @@ class HttpCache
             504 => 'Gateway Timeout',
             505 => 'HTTP Version Not Supported',
       );
+
+    /**
+     * @var HttpCache
+     */
     public static $instance = null;
+
     public static $header = array();
     public static $sessionPath = '';
     public static $sessionName = '';

--- a/Protocols/ProtocolInterface.php
+++ b/Protocols/ProtocolInterface.php
@@ -13,7 +13,7 @@
  */
 namespace Workerman\Protocols;
 
-use \Workerman\Connection\ConnectionInterface;
+use Workerman\Connection\ConnectionInterface;
 
 /**
  * Protocol interface

--- a/Protocols/Text.php
+++ b/Protocols/Text.php
@@ -12,7 +12,7 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Protocols;
-use \Workerman\Connection\TcpConnection;
+use Workerman\Connection\TcpConnection;
 
 /**
  * Text Protocol.
@@ -22,6 +22,8 @@ class Text
     /**
      * Check the integrity of the package.
      * @param string $buffer
+     * @param TcpConnection $connection
+     * @return int
      */
     public static function input($buffer ,TcpConnection $connection)
     {

--- a/Protocols/Websocket.php
+++ b/Protocols/Websocket.php
@@ -28,19 +28,21 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
     
     /**
      * Websocket blob type.
-     * @var char
+     * @var string
      */
     const BINARY_TYPE_BLOB = "\x81";
 
     /**
      * Websocket arraybuffer type.
-     * @var char
+     * @var string
      */
     const BINARY_TYPE_ARRAYBUFFER = "\x82";
     
     /**
      * Check the integrity of the package.
      * @param string $buffer
+     * @param ConnectionInterface $connection
+     * @return int
      */
     public static function input($buffer, ConnectionInterface $connection)
     {
@@ -219,6 +221,7 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
     /**
      * Websocket encode.
      * @param string $buffer
+     * @param ConnectionInterface $connection
      * @return string
      */
     public static function encode($buffer, ConnectionInterface $connection)
@@ -262,6 +265,7 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
     /**
      * Websocket decode.
      * @param string $buffer
+     * @param ConnectionInterface $connection
      * @return string
      */
     public static function decode($buffer, ConnectionInterface $connection)
@@ -297,7 +301,7 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
     /**
      * Websocket handshake.
      * @param string $buffer
-     * @param TcpConnection $connection
+     * @param \Workerman\Connection\TcpConnection $connection
      * @return int
      */
     protected static function dealHandshake($buffer, $connection)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Worker::runAll();
 test.php
 ```php
 require_once './Workerman/Autoloader.php';
-use \Workerman\WebServer;
+use Workerman\WebServer;
 
 // WebServer
 $web = new WebServer("http://0.0.0.0:80");

--- a/WebServer.php
+++ b/WebServer.php
@@ -13,9 +13,8 @@
  */
 namespace Workerman;
 
-use \Workerman\Worker;
-use \Workerman\Protocols\Http;
-use \Workerman\Protocols\HttpCache;
+use Workerman\Protocols\Http;
+use Workerman\Protocols\HttpCache;
 
 /**
  *  WebServer.
@@ -65,7 +64,7 @@ class WebServer extends Worker
      */
     public function __construct($socket_name, $context_option = array())
     {
-        list($scheme, $address) = explode(':', $socket_name, 2);
+        list(, $address) = explode(':', $socket_name, 2);
         parent::__construct('http:'.$address, $context_option);
         $this->name = 'WebServer';
     }
@@ -147,8 +146,7 @@ class WebServer extends Worker
     
     /**
      * Emit when http message coming.
-     * @param TcpConnection $connection
-     * @param mixed $data
+     * @param Connection\TcpConnection $connection
      * @return void
      */
     public function onMessage($connection)
@@ -158,7 +156,8 @@ class WebServer extends Worker
         if(!$workerman_url_info)
         {
             Http::header('HTTP/1.1 400 Bad Request');
-            return $connection->close('<h1>400 Bad Request</h1>');
+            $connection->close('<h1>400 Bad Request</h1>');
+            return;
         }
         
         $workerman_path = $workerman_url_info['path'];
@@ -192,7 +191,8 @@ class WebServer extends Worker
             if((!($workerman_request_realpath = realpath($workerman_file)) || !($workerman_root_dir_realpath = realpath($workerman_root_dir))) || 0 !== strpos($workerman_request_realpath, $workerman_root_dir_realpath))
             {
                 Http::header('HTTP/1.1 400 Bad Request');
-                return $connection->close('<h1>400 Bad Request</h1>');
+                $connection->close('<h1>400 Bad Request</h1>');
+                return;
             }
             
             $workerman_file = realpath($workerman_file);
@@ -224,7 +224,7 @@ class WebServer extends Worker
                 ini_set('display_errors', 'on');
                 $connection->close($content);
                 chdir($workerman_cwd);
-                return ;
+                return;
             }
             
             // Static resource file request.
@@ -250,7 +250,8 @@ class WebServer extends Worker
                     // 304
                     Http::header('HTTP/1.1 304 Not Modified');
                     // Send nothing but http headers..
-                    return $connection->close('');
+                    $connection->close('');
+                    return;
                 }
             }
             
@@ -259,13 +260,15 @@ class WebServer extends Worker
                 Http::header("Last-Modified: $modified_time");
             }
             // Send to client.
-           return $connection->close(file_get_contents($workerman_file));
+            $connection->close(file_get_contents($workerman_file));
+            return;
         }
         else 
         {
             // 404
             Http::header("HTTP/1.1 404 Not Found");
-            return $connection->close('<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>');
+            $connection->close('<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>');
+            return;
         }
     }
 }


### PR DESCRIPTION
1. 修正 phpdoc 文档错误。
2. 去除没用到的变量。
3. 去掉调用时冗余的接口参数，例如 Worker.php中，`self::log()`调用的第2个参数根据`log()`方法定义是不存在的。
4. 去掉 use 语句中多余的反斜杠(use 后面跟的肯定是带完整命名空间的类)， 例如`user \Exception; `改为`use Excetion;`。