### PR TITLE
Change coding style to PSR-2

### DIFF
--- a/Autoloader.php
+++ b/Autoloader.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman;
 
@@ -20,53 +20,50 @@ class Autoloader
 {
     /**
      * Autoload root path.
+     *
      * @var string
      */
     protected static $_autoloadRootPath = '';
-    
+
     /**
      * Set autoload root path.
+     *
      * @param string $root_path
      * @return void
      */
     public static function setRootPath($root_path)
     {
-          self::$_autoloadRootPath = $root_path;
+        self::$_autoloadRootPath = $root_path;
     }
 
     /**
      * Load files by namespace.
+     *
      * @param string $name
      * @return boolean
      */
     public static function loadByNamespace($name)
     {
-        $class_path = str_replace('\\', DIRECTORY_SEPARATOR ,$name);
-        if(strpos($name, 'Workerman\\') === 0)
-        {
-            $class_file = __DIR__.substr($class_path, strlen('Workerman')).'.php';
-        }
-        else 
-        {
-            if(self::$_autoloadRootPath)
-            {
-                $class_file = self::$_autoloadRootPath . DIRECTORY_SEPARATOR . $class_path.'.php';
+        $class_path = str_replace('\\', DIRECTORY_SEPARATOR, $name);
+        if (strpos($name, 'Workerman\\') === 0) {
+            $class_file = __DIR__ . substr($class_path, strlen('Workerman')) . '.php';
+        } else {
+            if (self::$_autoloadRootPath) {
+                $class_file = self::$_autoloadRootPath . DIRECTORY_SEPARATOR . $class_path . '.php';
             }
-            if(empty($class_file) || !is_file($class_file))
-            {
-                $class_file = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR . "$class_path.php";
+            if (empty($class_file) || !is_file($class_file)) {
+                $class_file = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . "$class_path.php";
             }
         }
-       
-        if(is_file($class_file))
-        {
+
+        if (is_file($class_file)) {
             require_once($class_file);
-            if(class_exists($name, false))
-            {
+            if (class_exists($name, false)) {
                 return true;
             }
         }
         return false;
     }
 }
+
 spl_autoload_register('\Workerman\Autoloader::loadByNamespace');

--- a/Connection/AsyncTcpConnection.php
+++ b/Connection/AsyncTcpConnection.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Connection;
 
@@ -22,55 +22,54 @@ use Exception;
  */
 class AsyncTcpConnection extends TcpConnection
 {
-    
     /**
-     * Emitted when socket connection is successfully established. 
+     * Emitted when socket connection is successfully established.
+     *
      * @var callback
      */
     public $onConnect = null;
-    
+
     /**
      * Status.
+     *
      * @var int
      */
     protected $_status = self::STATUS_CONNECTING;
-    
+
     /**
      * Construct.
+     *
      * @param string $remote_address
      * @throws Exception
      */
     public function __construct($remote_address)
     {
         list($scheme, $address) = explode(':', $remote_address, 2);
-        if($scheme != 'tcp')
-        {
+        if ($scheme != 'tcp') {
             // Get application layer protocol.
-            $scheme = ucfirst($scheme);
-            $this->protocol = '\\Protocols\\'.$scheme;
-            if(!class_exists($this->protocol))
-            {
+            $scheme         = ucfirst($scheme);
+            $this->protocol = '\\Protocols\\' . $scheme;
+            if (!class_exists($this->protocol)) {
                 $this->protocol = '\\Workerman\\Protocols\\' . $scheme;
-                if(!class_exists($this->protocol))
-                {
+                if (!class_exists($this->protocol)) {
                     throw new Exception("class \\Protocols\\$scheme not exist");
                 }
             }
         }
         $this->_remoteAddress = substr($address, 2);
-        $this->id = self::$_idRecorder++;
+        $this->id             = self::$_idRecorder++;
         // For statistics.
         self::$statistics['connection_count']++;
         $this->maxSendBufferSize = self::$defaultMaxSendBufferSize;
     }
-    
+
     public function connect()
     {
         // Open socket connection asynchronously.
-        $this->_socket = stream_socket_client("tcp://{$this->_remoteAddress}", $errno, $errstr, 0, STREAM_CLIENT_ASYNC_CONNECT);
+        $this->_socket = stream_socket_client("tcp://{$this->_remoteAddress}", $errno, $errstr, 0,
+            STREAM_CLIENT_ASYNC_CONNECT);
         // If failed attempt to emit onError callback.
-        if(!$this->_socket)
-        {
+        if (!$this->_socket) {
             $this->_status = self::STATUS_CLOSED;
             $this->emitError(WORKERMAN_CONNECT_FAIL, $errstr);
             return;
@@ -78,46 +77,42 @@ class AsyncTcpConnection extends TcpConnection
         // Add socket to global event loop waiting connection is successfully established or faild. 
         Worker::$globalEvent->add($this->_socket, EventInterface::EV_WRITE, array($this, 'checkConnection'));
     }
-    
+
     /**
      * Try to emit onError callback.
-     * @param int $code
+     *
+     * @param int    $code
      * @param string $msg
      * @return void
      */
     protected function emitError($code, $msg)
     {
-        if($this->onError)
-        {
-            try
-            {
+        if ($this->onError) {
+            try {
                 call_user_func($this->onError, $this, $code, $msg);
-            }
-            catch(\Exception $e)
-            {
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
         }
     }
-    
+
     /**
      * Check connection is successfully established or faild.
+     *
      * @param resource $socket
      * @return void
      */
     public function checkConnection($socket)
     {
         // Need call foef twice.
-        if(!feof($this->_socket) && !feof($this->_socket) && is_resource($this->_socket))
-        {
+        if (!feof($this->_socket) && !feof($this->_socket) && is_resource($this->_socket)) {
             // Remove write listener.
             Worker::$globalEvent->del($this->_socket, EventInterface::EV_WRITE);
             // Nonblocking.
             stream_set_blocking($this->_socket, 0);
             // Try to open keepalive for tcp and disable Nagle algorithm.
-            if(function_exists('socket_import_stream'))
-            {
+            if (function_exists('socket_import_stream')) {
                 $raw_socket = socket_import_stream($this->_socket);
                 socket_set_option($raw_socket, SOL_SOCKET, SO_KEEPALIVE, 1);
                 socket_set_option($raw_socket, SOL_TCP, TCP_NODELAY, 1);
@@ -125,28 +120,21 @@ class AsyncTcpConnection extends TcpConnection
             // Register a listener waiting read event.
             Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ, array($this, 'baseRead'));
             // There are some data waiting to send.
-            if($this->_sendBuffer)
-            {
+            if ($this->_sendBuffer) {
                 Worker::$globalEvent->add($this->_socket, EventInterface::EV_WRITE, array($this, 'baseWrite'));
             }
-            $this->_status = self::STATUS_ESTABLISH;
+            $this->_status        = self::STATUS_ESTABLISH;
             $this->_remoteAddress = stream_socket_get_name($this->_socket, true);
             // Try to emit onConnect callback.
-            if($this->onConnect)
-            {
-                try
-                {
+            if ($this->onConnect) {
+                try {
                     call_user_func($this->onConnect, $this);
-                }
-                catch(\Exception $e)
-                {
+                } catch (\Exception $e) {
                     echo $e;
                     exit(250);
                 }
             }
-        }
-        else
-        {
+        } else {
             // Connection failed.
             $this->emitError(WORKERMAN_CONNECT_FAIL, 'connect fail');
             $this->destroy();

--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Connection;
 
@@ -20,48 +20,55 @@ abstract class  ConnectionInterface
 {
     /**
      * Statistics for status command.
+     *
      * @var array
      */
     public static $statistics = array(
-        'connection_count'=>0,
-        'total_request'   => 0, 
-        'throw_exception' => 0,
-        'send_fail'       => 0,
+        'connection_count' => 0,
+        'total_request'    => 0,
+        'throw_exception'  => 0,
+        'send_fail'        => 0,
     );
-    
+
     /**
-     * Emitted when data is received. 
+     * Emitted when data is received.
+     *
      * @var callback
      */
     public $onMessage = null;
-    
+
     /**
      * Emitted when the other end of the socket sends a FIN packet.
+     *
      * @var callback
      */
     public $onClose = null;
-    
+
     /**
-     * Emitted when an error occurs with connection. 
+     * Emitted when an error occurs with connection.
+     *
      * @var callback
      */
     public $onError = null;
-    
+
     /**
      * Sends data on the connection.
+     *
      * @param string $send_buffer
      * @return void|boolean
      */
     abstract public function send($send_buffer);
-    
+
     /**
      * Get remote IP.
+     *
      * @return string
      */
     abstract public function getRemoteIp();
-    
+
     /**
      * Get remote port.
+     *
      * @return int
      */
     abstract public function getRemotePort();

--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Connection;
 
@@ -24,229 +24,241 @@ class TcpConnection extends ConnectionInterface
 {
     /**
      * Read buffer size.
+     *
      * @var int
      */
     const READ_BUFFER_SIZE = 65535;
 
     /**
      * Status connecting.
+     *
      * @var int
      */
     const STATUS_CONNECTING = 1;
-    
+
     /**
      * Status connection established.
+     *
      * @var int
      */
     const STATUS_ESTABLISH = 2;
 
     /**
      * Status closing.
+     *
      * @var int
      */
     const STATUS_CLOSING = 4;
-    
+
     /**
      * Status closed.
+     *
      * @var int
      */
     const STATUS_CLOSED = 8;
-    
+
     /**
-     * Emitted when data is received. 
+     * Emitted when data is received.
+     *
      * @var callback
      */
     public $onMessage = null;
-    
+
     /**
      * Emitted when the other end of the socket sends a FIN packet.
+     *
      * @var callback
      */
     public $onClose = null;
-    
+
     /**
-     * Emitted when an error occurs with connection. 
+     * Emitted when an error occurs with connection.
+     *
      * @var callback
      */
     public $onError = null;
-    
+
     /**
-     * Emitted when the send buffer becomes full. 
+     * Emitted when the send buffer becomes full.
+     *
      * @var callback
      */
     public $onBufferFull = null;
-    
+
     /**
      * Emitted when the send buffer becomes empty.
+     *
      * @var callback
      */
     public $onBufferDrain = null;
-    
+
     /**
      * Application layer protocol.
      * The format is like this Workerman\\Protocols\\Http.
+     *
      * @var \Workerman\Protocols\ProtocolInterface
      */
     public $protocol = null;
-    
+
     /**
      * Which worker belong to.
+     *
      * @var Worker
      */
     public $worker = null;
-    
+
     /**
      * Connection->id.
+     *
      * @var int
      */
     public $id = 0;
-    
+
     /**
      * A copy of $worker->id which used to clean up the connection in worker->connections
+     *
      * @var int
      */
     protected $_id = 0;
-    
+
     /**
      * Sets the maximum send buffer size for the current connection.
      * OnBufferFull callback will be emited When the send buffer is full.
+     *
      * @var int
      */
     public $maxSendBufferSize = 1048576;
-    
+
     /**
      * Default send buffer size.
+     *
      * @var int
      */
     public static $defaultMaxSendBufferSize = 1048576;
-    
+
     /**
      * Maximum acceptable packet size.
+     *
      * @var int
      */
     public static $maxPackageSize = 10485760;
-    
+
     /**
      * Id recorder.
+     *
      * @var int
      */
     protected static $_idRecorder = 1;
-    
+
     /**
      * Socket
+     *
      * @var resource
      */
     protected $_socket = null;
 
     /**
      * Send buffer.
+     *
      * @var string
      */
     protected $_sendBuffer = '';
-    
+
     /**
      * Receive buffer.
+     *
      * @var string
      */
     protected $_recvBuffer = '';
-    
+
     /**
      * Current package length.
+     *
      * @var int
      */
     protected $_currentPackageLength = 0;
-    
+
     /**
      * Connection status.
+     *
      * @var int
      */
     protected $_status = self::STATUS_ESTABLISH;
-    
+
     /**
      * Remote address.
+     *
      * @var string
      */
     protected $_remoteAddress = '';
-    
+
     /**
      * Is paused.
+     *
      * @var bool
      */
     protected $_isPaused = false;
-    
+
     /**
      * Construct.
+     *
      * @param resource $socket
-     * @param string $remote_address
+     * @param string   $remote_address
      */
     public function __construct($socket, $remote_address = '')
     {
         self::$statistics['connection_count']++;
-        $this->id = $this->_id = self::$_idRecorder++;
+        $this->id      = $this->_id = self::$_idRecorder++;
         $this->_socket = $socket;
         stream_set_blocking($this->_socket, 0);
         Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ, array($this, 'baseRead'));
         $this->maxSendBufferSize = self::$defaultMaxSendBufferSize;
-        $this->_remoteAddress = $remote_address;
+        $this->_remoteAddress    = $remote_address;
     }
-    
+
     /**
      * Sends data on the connection.
+     *
      * @param string $send_buffer
-     * @param bool $raw
+     * @param bool   $raw
      * @return void|bool|null
      */
     public function send($send_buffer, $raw = false)
     {
         // Try to call protocol::encode($send_buffer) before sending.
-        if(false === $raw && $this->protocol)
-        {
-            $parser = $this->protocol;
+        if (false === $raw && $this->protocol) {
+            $parser      = $this->protocol;
             $send_buffer = $parser::encode($send_buffer, $this);
-            if($send_buffer === '')
-            {
+            if ($send_buffer === '') {
                 return null;
             }
         }
-        
-        if($this->_status === self::STATUS_CONNECTING)
-        {
+
+        if ($this->_status === self::STATUS_CONNECTING) {
             $this->_sendBuffer .= $send_buffer;
             return null;
-        }
-        elseif($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED)
-        {
+        } elseif ($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED) {
             return false;
         }
-        
+
         // Attempt to send data directly.
-        if($this->_sendBuffer === '')
-        {
+        if ($this->_sendBuffer === '') {
             $len = @fwrite($this->_socket, $send_buffer);
             // send successful.
-            if($len === strlen($send_buffer))
-            {
+            if ($len === strlen($send_buffer)) {
                 return true;
             }
             // Send only part of the data.
-            if($len > 0)
-            {
+            if ($len > 0) {
                 $this->_sendBuffer = substr($send_buffer, $len);
-            }
-            else
-            {
+            } else {
                 // Connection closed?
-                if(!is_resource($this->_socket) || feof($this->_socket))
-                {
+                if (!is_resource($this->_socket) || feof($this->_socket)) {
                     self::$statistics['send_fail']++;
-                    if($this->onError)
-                    {
-                        try
-                        {
+                    if ($this->onError) {
+                        try {
                             call_user_func($this->onError, $this, WORKERMAN_SEND_FAIL, 'client closed');
-                        }
-                        catch(\Exception $e)
-                        {
+                        } catch (\Exception $e) {
                             echo $e;
                             exit(250);
                         }
@@ -260,21 +272,14 @@ class TcpConnection extends ConnectionInterface
             // Check if the send buffer is full.
             $this->checkBufferIsFull();
             return null;
-        }
-        else
-        {
+        } else {
             // Buffer has been marked as full but still has data to send the packet is discarded.
-            if($this->maxSendBufferSize <= strlen($this->_sendBuffer))
-            {
+            if ($this->maxSendBufferSize <= strlen($this->_sendBuffer)) {
                 self::$statistics['send_fail']++;
-                if($this->onError)
-                {
-                    try
-                    {
+                if ($this->onError) {
+                    try {
                         call_user_func($this->onError, $this, WORKERMAN_SEND_FAIL, 'send buffer full and drop package');
-                    }
-                    catch(\Exception $e)
-                    {
+                    } catch (\Exception $e) {
                         echo $e;
                         exit(250);
                     }
@@ -286,36 +291,37 @@ class TcpConnection extends ConnectionInterface
             $this->checkBufferIsFull();
         }
     }
-    
+
     /**
      * Get remote IP.
+     *
      * @return string
      */
     public function getRemoteIp()
     {
         $pos = strrpos($this->_remoteAddress, ':');
-        if($pos)
-        {
+        if ($pos) {
             return substr($this->_remoteAddress, 0, $pos);
         }
         return '';
     }
-    
+
     /**
      * Get remote port.
+     *
      * @return int
      */
     public function getRemotePort()
     {
-        if($this->_remoteAddress)
-        {
+        if ($this->_remoteAddress) {
             return (int)substr(strrchr($this->_remoteAddress, ':'), 1);
         }
         return 0;
     }
-    
+
     /**
      * Pauses the reading of data. That is onMessage will not be emitted. Useful to throttle back an upload.
+     *
      * @return void
      */
     public function pauseRecv()
@@ -323,15 +329,15 @@ class TcpConnection extends ConnectionInterface
         Worker::$globalEvent->del($this->_socket, EventInterface::EV_READ);
         $this->_isPaused = true;
     }
-    
+
     /**
      * Resumes reading after a call to pauseRecv.
+     *
      * @return void
      */
     public function resumeRecv()
     {
-        if($this->_isPaused === true)
-        {
+        if ($this->_isPaused === true) {
             Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ, array($this, 'baseRead'));
             $this->_isPaused = false;
             $this->baseRead($this->_socket, false);
@@ -340,124 +346,98 @@ class TcpConnection extends ConnectionInterface
 
     /**
      * Base read handler.
+     *
      * @param resource $socket
      * @return void
      */
     public function baseRead($socket, $check_eof = true)
     {
         $read_data = false;
-        while(1)
-        {
+        while (1) {
             $buffer = fread($socket, self::READ_BUFFER_SIZE);
-            if($buffer === '' || $buffer === false)
-            {
+            if ($buffer === '' || $buffer === false) {
                 break;
             }
             $read_data = true;
             $this->_recvBuffer .= $buffer;
         }
-        
+
         // Check connection closed.
-        if(!$read_data && $check_eof)
-        {
+        if (!$read_data && $check_eof) {
             $this->destroy();
             return;
         }
-        
+
         // If the application layer protocol has been set up.
-        if($this->protocol)
-        {
-           $parser = $this->protocol;
-           while($this->_recvBuffer !== '' && !$this->_isPaused)
-           {
-               // The current packet length is known.
-               if($this->_currentPackageLength)
-               {
-                   // Data is not enough for a package.
-                   if($this->_currentPackageLength > strlen($this->_recvBuffer))
-                   {
-                       break;
-                   }
-               }
-               else
-               {
-                   // Get current package length.
-                   $this->_currentPackageLength = $parser::input($this->_recvBuffer, $this);
-                   // The packet length is unknown.
-                   if($this->_currentPackageLength === 0)
-                   {
-                       break;
-                   }
-                   elseif($this->_currentPackageLength > 0 && $this->_currentPackageLength <= self::$maxPackageSize)
-                   {
-                       // Data is not enough for a package.
-                       if($this->_currentPackageLength > strlen($this->_recvBuffer))
-                       {
-                           break;
-                       }
-                   }
-                   // Wrong package.
-                   else
-                   {
-                       echo 'error package. package_length='.var_export($this->_currentPackageLength, true);
-                       $this->destroy();
-                       return;
-                   }
-               }
-               
-               // The data is enough for a packet.
-               self::$statistics['total_request']++;
-               // The current packet length is equal to the length of the buffer.
-               if(strlen($this->_recvBuffer) === $this->_currentPackageLength)
-               {
-                   $one_request_buffer = $this->_recvBuffer;
-                   $this->_recvBuffer = '';
-               }
-               else
-               {
-                   // Get a full package from the buffer.
-                   $one_request_buffer = substr($this->_recvBuffer, 0, $this->_currentPackageLength);
-                   // Remove the current package from the receive buffer.
-                   $this->_recvBuffer = substr($this->_recvBuffer, $this->_currentPackageLength);
-               }
-               // Reset the current packet length to 0.
-               $this->_currentPackageLength = 0;
-               if(!$this->onMessage)
-               {
-                   continue ;
-               }
-               try
-               {
-                   // Decode request buffer before Emiting onMessage callback.
-                   call_user_func($this->onMessage, $this, $parser::decode($one_request_buffer, $this));
-               }
-                catch(\Exception $e)
-                {
+        if ($this->protocol) {
+            $parser = $this->protocol;
+            while ($this->_recvBuffer !== '' && !$this->_isPaused) {
+                // The current packet length is known.
+                if ($this->_currentPackageLength) {
+                    // Data is not enough for a package.
+                    if ($this->_currentPackageLength > strlen($this->_recvBuffer)) {
+                        break;
+                    }
+                } else {
+                    // Get current package length.
+                    $this->_currentPackageLength = $parser::input($this->_recvBuffer, $this);
+                    // The packet length is unknown.
+                    if ($this->_currentPackageLength === 0) {
+                        break;
+                    } elseif ($this->_currentPackageLength > 0 && $this->_currentPackageLength <= self::$maxPackageSize) {
+                        // Data is not enough for a package.
+                        if ($this->_currentPackageLength > strlen($this->_recvBuffer)) {
+                            break;
+                        }
+                    } // Wrong package.
+                    else {
+                        echo 'error package. package_length=' . var_export($this->_currentPackageLength, true);
+                        $this->destroy();
+                        return;
+                    }
+                }
+
+                // The data is enough for a packet.
+                self::$statistics['total_request']++;
+                // The current packet length is equal to the length of the buffer.
+                if (strlen($this->_recvBuffer) === $this->_currentPackageLength) {
+                    $one_request_buffer = $this->_recvBuffer;
+                    $this->_recvBuffer  = '';
+                } else {
+                    // Get a full package from the buffer.
+                    $one_request_buffer = substr($this->_recvBuffer, 0, $this->_currentPackageLength);
+                    // Remove the current package from the receive buffer.
+                    $this->_recvBuffer = substr($this->_recvBuffer, $this->_currentPackageLength);
+                }
+                // Reset the current packet length to 0.
+                $this->_currentPackageLength = 0;
+                if (!$this->onMessage) {
+                    continue;
+                }
+                try {
+                    // Decode request buffer before Emiting onMessage callback.
+                    call_user_func($this->onMessage, $this, $parser::decode($one_request_buffer, $this));
+                } catch (\Exception $e) {
                     echo $e;
                     exit(250);
                 }
-           }
-           return;
-        }
-        
-        if($this->_recvBuffer === '' || $this->_isPaused)
-        {
+            }
             return;
         }
-        
+
+        if ($this->_recvBuffer === '' || $this->_isPaused) {
+            return;
+        }
+
         // Applications protocol is not set.
         self::$statistics['total_request']++;
-        if(!$this->onMessage)
-        {
+        if (!$this->onMessage) {
             $this->_recvBuffer = '';
-            return ;
+            return;
         }
-        try
-        {
+        try {
             call_user_func($this->onMessage, $this, $this->_recvBuffer);
-        }
-        catch(\Exception $e)
-        {
+        } catch (\Exception $e) {
             echo $e;
             exit(250);
         }
@@ -467,73 +447,63 @@ class TcpConnection extends ConnectionInterface
 
     /**
      * Base write handler.
+     *
      * @return void|bool
      */
     public function baseWrite()
     {
         $len = @fwrite($this->_socket, $this->_sendBuffer);
-        if($len === strlen($this->_sendBuffer))
-        {
+        if ($len === strlen($this->_sendBuffer)) {
             Worker::$globalEvent->del($this->_socket, EventInterface::EV_WRITE);
             $this->_sendBuffer = '';
             // Try to emit onBufferDrain callback when the send buffer becomes empty. 
-            if($this->onBufferDrain)
-            {
-                try
-                {
+            if ($this->onBufferDrain) {
+                try {
                     call_user_func($this->onBufferDrain, $this);
-                }
-                catch(\Exception $e)
-                {
+                } catch (\Exception $e) {
                     echo $e;
                     exit(250);
                 }
             }
-            if($this->_status === self::STATUS_CLOSING)
-            {
+            if ($this->_status === self::STATUS_CLOSING) {
                 $this->destroy();
             }
             return true;
         }
-        if($len > 0)
-        {
-           $this->_sendBuffer = substr($this->_sendBuffer, $len);
-        }
-        else
-        {
+        if ($len > 0) {
+            $this->_sendBuffer = substr($this->_sendBuffer, $len);
+        } else {
             self::$statistics['send_fail']++;
             $this->destroy();
         }
     }
-    
+
     /**
      * This method pulls all the data out of a readable stream, and writes it to the supplied destination.
+     *
      * @param TcpConnection $dest
      * @return void
      */
     public function pipe($dest)
     {
-        $source = $this;
-        $this->onMessage = function($source, $data)use($dest)
-        {
+        $source              = $this;
+        $this->onMessage     = function ($source, $data) use ($dest) {
             $dest->send($data);
         };
-        $this->onClose = function($source)use($dest)
-        {
+        $this->onClose       = function ($source) use ($dest) {
             $dest->destroy();
         };
-        $dest->onBufferFull = function($dest)use($source)
-        {
+        $dest->onBufferFull  = function ($dest) use ($source) {
             $source->pauseRecv();
         };
-        $dest->onBufferDrain = function($dest)use($source)
-        {
+        $dest->onBufferDrain = function ($dest) use ($source) {
             $source->resumeRecv();
         };
     }
-    
+
     /**
      * Remove $length of data from receive buffer.
+     *
      * @param int $length
      * @return void
      */
@@ -544,31 +514,28 @@ class TcpConnection extends ConnectionInterface
 
     /**
      * Close connection.
+     *
      * @param mixed $data
      * @return void
      */
     public function close($data = null)
     {
-        if($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED)
-        {
+        if ($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED) {
             return;
-        }
-        else
-        {
-            if($data !== null)
-            {
+        } else {
+            if ($data !== null) {
                 $this->send($data);
             }
             $this->_status = self::STATUS_CLOSING;
         }
-        if($this->_sendBuffer === '')
-        {
-           $this->destroy();
+        if ($this->_sendBuffer === '') {
+            $this->destroy();
         }
     }
-    
+
     /**
      * Get the real socket.
+     *
      * @return resource
      */
     public function getSocket()
@@ -578,35 +545,32 @@ class TcpConnection extends ConnectionInterface
 
     /**
      * Check whether the send buffer is full.
+     *
      * @return void
      */
     protected function checkBufferIsFull()
     {
-        if($this->maxSendBufferSize <= strlen($this->_sendBuffer))
-        {
-            if($this->onBufferFull)
-            {
-                try
-                {
+        if ($this->maxSendBufferSize <= strlen($this->_sendBuffer)) {
+            if ($this->onBufferFull) {
+                try {
                     call_user_func($this->onBufferFull, $this);
-                }
-                catch(\Exception $e)
-                {
+                } catch (\Exception $e) {
                     echo $e;
                     exit(250);
                 }
             }
         }
     }
+
     /**
      * Destroy connection.
+     *
      * @return void
      */
     public function destroy()
     {
         // Avoid repeated calls.
-        if($this->_status === self::STATUS_CLOSED)
-        {
+        if ($this->_status === self::STATUS_CLOSED) {
             return;
         }
         // Remove event listener.
@@ -615,20 +579,15 @@ class TcpConnection extends ConnectionInterface
         // Close socket.
         @fclose($this->_socket);
         // Remove from worker->connections.
-        if($this->worker)
-        {
+        if ($this->worker) {
             unset($this->worker->connections[$this->_id]);
         }
         $this->_status = self::STATUS_CLOSED;
         // Try to emit onClose callback.
-        if($this->onClose)
-        {
-            try
-            {
-               call_user_func($this->onClose, $this);
-            }
-            catch(\Exception $e)
-            {
+        if ($this->onClose) {
+            try {
+                call_user_func($this->onClose, $this);
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
@@ -636,9 +595,10 @@ class TcpConnection extends ConnectionInterface
         // Cleaning up the callback to avoid memory leaks.
         $this->onMessage = $this->onClose = $this->onError = $this->onBufferFull = $this->onBufferDrain = null;
     }
-    
+
     /**
      * Destruct.
+     *
      * @return void
      */
     public function __destruct()

--- a/Connection/UdpConnection.php
+++ b/Connection/UdpConnection.php
@@ -6,101 +6,106 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Connection;
 
 /**
- * UdpConnection. 
+ * UdpConnection.
  */
 class UdpConnection extends ConnectionInterface
 {
     /**
      * Application layer protocol.
      * The format is like this Workerman\\Protocols\\Http.
+     *
      * @var \Workerman\Protocols\ProtocolInterface
      */
     public $protocol = null;
-    
+
     /**
      * Udp socket.
+     *
      * @var resource
      */
     protected $_socket = null;
-    
+
     /**
      * Remote ip.
+     *
      * @var string
      */
     protected $_remoteIp = '';
-    
+
     /**
      * Remote port.
+     *
      * @var int
      */
     protected $_remotePort = 0;
-    
+
     /**
      * Remote address.
+     *
      * @var string
      */
     protected $_remoteAddress = '';
 
     /**
      * Construct.
+     *
      * @param resource $socket
-     * @param string $remote_address
+     * @param string   $remote_address
      */
     public function __construct($socket, $remote_address)
     {
-        $this->_socket = $socket;
+        $this->_socket        = $socket;
         $this->_remoteAddress = $remote_address;
     }
-    
+
     /**
      * Sends data on the connection.
+     *
      * @param string $send_buffer
-     * @param bool $raw
+     * @param bool   $raw
      * @return void|boolean
      */
     public function send($send_buffer, $raw = false)
     {
-        if(false === $raw && $this->protocol)
-        {
-            $parser = $this->protocol;
+        if (false === $raw && $this->protocol) {
+            $parser      = $this->protocol;
             $send_buffer = $parser::encode($send_buffer, $this);
-            if($send_buffer === '')
-            {
+            if ($send_buffer === '') {
                 return null;
             }
         }
         return strlen($send_buffer) === stream_socket_sendto($this->_socket, $send_buffer, 0, $this->_remoteAddress);
     }
-    
+
     /**
      * Get remote IP.
+     *
      * @return string
      */
     public function getRemoteIp()
     {
-        if(!$this->_remoteIp)
-        {
+        if (!$this->_remoteIp) {
             list($this->_remoteIp, $this->_remotePort) = explode(':', $this->_remoteAddress, 2);
         }
         return $this->_remoteIp;
     }
-    
+
     /**
      * Get remote port.
+     *
      * @return int
      */
     public function getRemotePort()
     {
-        if(!$this->_remotePort)
-        {
+        if (!$this->_remotePort) {
             list($this->_remoteIp, $this->_remotePort) = explode(':', $this->_remoteAddress, 2);
         }
         return $this->_remotePort;
@@ -114,8 +119,7 @@ class UdpConnection extends ConnectionInterface
      */
     public function close($data = null)
     {
-        if($data !== null)
-        {
+        if ($data !== null) {
             $this->send($data);
         }
         return true;

--- a/Events/Ev.php
+++ b/Events/Ev.php
@@ -6,8 +6,8 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author 有个鬼<42765633@qq.com>
- * @link http://www.workerman.net/
+ * @author  有个鬼<42765633@qq.com>
+ * @link    http://www.workerman.net/
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Events;
@@ -19,12 +19,14 @@ class Ev implements EventInterface
 {
     /**
      * All listeners for read/write event.
+     *
      * @var array
      */
     protected $_allEvents = array();
 
     /**
      * Event listeners of signal.
+     *
      * @var array
      */
     protected $_eventSignal = array();
@@ -32,12 +34,14 @@ class Ev implements EventInterface
     /**
      * All timer event listeners.
      * [func, args, event, flag, time_interval]
+     *
      * @var array
      */
     protected $_eventTimer = array();
 
     /**
      * Timer id.
+     *
      * @var int
      */
     protected static $_timerId = 1;
@@ -46,38 +50,33 @@ class Ev implements EventInterface
      * Add a timer.
      * {@inheritdoc}
      */
-    public function add($fd, $flag, $func, $args=null)
+    public function add($fd, $flag, $func, $args = null)
     {
-        $callback = function($event,$socket)use($fd,$func)
-        {
-            try
-            {
-                call_user_func($func,$fd);
-            }
-            catch(\Exception $e)
-            {
+        $callback = function ($event, $socket) use ($fd, $func) {
+            try {
+                call_user_func($func, $fd);
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
         };
 
-        switch($flag)
-        {
+        switch ($flag) {
             case self::EV_SIGNAL:
-                $event = new \EvSignal($fd, $callback);
+                $event                   = new \EvSignal($fd, $callback);
                 $this->_eventSignal[$fd] = $event;
                 return true;
             case self::EV_TIMER:
             case self::EV_TIMER_ONCE:
-                $repeat = $flag==self::EV_TIMER_ONCE ? 0 : $fd;
-                $param = array($func, (array)$args, $flag, $fd, self::$_timerId);
-                $event = new \EvTimer($fd, $repeat, array($this, 'timerCallback'),$param);
+                $repeat                             = $flag == self::EV_TIMER_ONCE ? 0 : $fd;
+                $param                              = array($func, (array)$args, $flag, $fd, self::$_timerId);
+                $event                              = new \EvTimer($fd, $repeat, array($this, 'timerCallback'), $param);
                 $this->_eventTimer[self::$_timerId] = $event;
                 return self::$_timerId++;
             default :
-                $fd_key = (int)$fd;
-                $real_flag = $flag === self::EV_READ ? \Ev::READ : \Ev::WRITE;
-                $event = new \EvIo($fd, $real_flag, $callback);
+                $fd_key                           = (int)$fd;
+                $real_flag                        = $flag === self::EV_READ ? \Ev::READ : \Ev::WRITE;
+                $event                            = new \EvIo($fd, $real_flag, $callback);
                 $this->_allEvents[$fd_key][$flag] = $event;
                 return true;
         }
@@ -88,35 +87,30 @@ class Ev implements EventInterface
      * Remove a timer.
      * {@inheritdoc}
      */
-    public function del($fd ,$flag)
+    public function del($fd, $flag)
     {
-        switch($flag)
-        {
+        switch ($flag) {
             case self::EV_READ:
             case self::EV_WRITE:
                 $fd_key = (int)$fd;
-                if(isset($this->_allEvents[$fd_key][$flag]))
-                {
+                if (isset($this->_allEvents[$fd_key][$flag])) {
                     $this->_allEvents[$fd_key][$flag]->stop();
                     unset($this->_allEvents[$fd_key][$flag]);
                 }
-                if(empty($this->_allEvents[$fd_key]))
-                {
+                if (empty($this->_allEvents[$fd_key])) {
                     unset($this->_allEvents[$fd_key]);
                 }
                 break;
             case  self::EV_SIGNAL:
                 $fd_key = (int)$fd;
-                if(isset($this->_eventSignal[$fd_key]))
-                {
+                if (isset($this->_eventSignal[$fd_key])) {
                     $this->_allEvents[$fd_key][$flag]->stop();
                     unset($this->_eventSignal[$fd_key]);
                 }
                 break;
             case self::EV_TIMER:
             case self::EV_TIMER_ONCE:
-                if(isset($this->_eventTimer[$fd]))
-                {
+                if (isset($this->_eventTimer[$fd])) {
                     $this->_eventTimer[$fd]->stop();
                     unset($this->_eventTimer[$fd]);
                 }
@@ -127,23 +121,20 @@ class Ev implements EventInterface
 
     /**
      * Timer callback.
+     *
      * @param \EvWatcher $event
      */
     public function timerCallback($event)
     {
-        $param = $event->data;
+        $param    = $event->data;
         $timer_id = $param[4];
-        if($param[2] === self::EV_TIMER_ONCE)
-        {
+        if ($param[2] === self::EV_TIMER_ONCE) {
             $this->_eventTimer[$timer_id]->stop();
             unset($this->_eventTimer[$timer_id]);
         }
-        try
-        {
-            call_user_func_array($param[0],$param[1]);
-        }
-        catch(\Exception $e)
-        {
+        try {
+            call_user_func_array($param[0], $param[1]);
+        } catch (\Exception $e) {
             echo $e;
             exit(250);
         }
@@ -151,12 +142,12 @@ class Ev implements EventInterface
 
     /**
      * Remove all timers.
+     *
      * @return void
      */
     public function clearAllTimer()
     {
-        foreach($this->_eventTimer as $event)
-        {
+        foreach ($this->_eventTimer as $event) {
             $event->stop();
         }
         $this->_eventTimer = array();
@@ -164,6 +155,7 @@ class Ev implements EventInterface
 
     /**
      * Main loop.
+     *
      * @see EventInterface::loop()
      */
     public function loop()

--- a/Events/EventInterface.php
+++ b/Events/EventInterface.php
@@ -6,71 +6,80 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Events;
 
 interface EventInterface
 {
     /**
-     * Read event. 
+     * Read event.
+     *
      * @var int
      */
     const EV_READ = 1;
-    
+
     /**
      * Write event.
+     *
      * @var int
      */
     const EV_WRITE = 2;
-    
+
     /**
      * Signal event.
+     *
      * @var int
      */
     const EV_SIGNAL = 4;
-    
+
     /**
      * Timer event.
+     *
      * @var int
      */
     const EV_TIMER = 8;
-    
+
     /**
      * Timer once event.
-     * @var int 
+     *
+     * @var int
      */
     const EV_TIMER_ONCE = 16;
-    
+
     /**
      * Add event listener to event loop.
-     * @param mixed $fd
-     * @param int $flag
+     *
+     * @param mixed    $fd
+     * @param int      $flag
      * @param callable $func
-     * @param mixed $args
+     * @param mixed    $args
      * @return bool
      */
     public function add($fd, $flag, $func, $args = null);
-    
+
     /**
      * Remove event listener from event loop.
+     *
      * @param mixed $fd
-     * @param int $flag
+     * @param int   $flag
      * @return bool
      */
     public function del($fd, $flag);
-    
+
     /**
      * Remove all timers.
+     *
      * @return void
      */
     public function clearAllTimer();
-    
+
     /**
      * Main loop.
+     *
      * @return void
      */
     public function loop();

--- a/Events/Libevent.php
+++ b/Events/Libevent.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of workerman.
  *
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Events;
 
@@ -20,29 +20,33 @@ class Libevent implements EventInterface
 {
     /**
      * Event base.
+     *
      * @var resource
      */
     protected $_eventBase = null;
-    
+
     /**
      * All listeners for read/write event.
+     *
      * @var array
      */
     protected $_allEvents = array();
-    
+
     /**
      * Event listeners of signal.
+     *
      * @var array
      */
     protected $_eventSignal = array();
-    
+
     /**
      * All timer event listeners.
      * [func, args, event, flag, time_interval]
+     *
      * @var array
      */
     protected $_eventTimer = array();
-    
+
     /**
      * construct
      */
@@ -50,105 +54,91 @@ class Libevent implements EventInterface
     {
         $this->_eventBase = event_base_new();
     }
-   
+
     /**
      * {@inheritdoc}
      */
-    public function add($fd, $flag, $func, $args=array())
+    public function add($fd, $flag, $func, $args = array())
     {
-        switch($flag)
-        {
+        switch ($flag) {
             case self::EV_SIGNAL:
-                $fd_key = (int)$fd;
-                $real_flag = EV_SIGNAL | EV_PERSIST;
+                $fd_key                      = (int)$fd;
+                $real_flag                   = EV_SIGNAL | EV_PERSIST;
                 $this->_eventSignal[$fd_key] = event_new();
-                if(!event_set($this->_eventSignal[$fd_key], $fd, $real_flag, $func, null))
-                {
+                if (!event_set($this->_eventSignal[$fd_key], $fd, $real_flag, $func, null)) {
                     return false;
                 }
-                if(!event_base_set($this->_eventSignal[$fd_key], $this->_eventBase))
-                {
+                if (!event_base_set($this->_eventSignal[$fd_key], $this->_eventBase)) {
                     return false;
                 }
-                if(!event_add($this->_eventSignal[$fd_key]))
-                {
+                if (!event_add($this->_eventSignal[$fd_key])) {
                     return false;
                 }
                 return true;
             case self::EV_TIMER:
             case self::EV_TIMER_ONCE:
-                $event = event_new();
+                $event    = event_new();
                 $timer_id = (int)$event;
-                if(!event_set($event, 0, EV_TIMEOUT, array($this, 'timerCallback'), $timer_id))
-                {
+                if (!event_set($event, 0, EV_TIMEOUT, array($this, 'timerCallback'), $timer_id)) {
                     return false;
                 }
-                
-                if(!event_base_set($event, $this->_eventBase))
-                {
+
+                if (!event_base_set($event, $this->_eventBase)) {
                     return false;
                 }
-                
-                $time_interval = $fd*1000000;
-                if(!event_add($event, $time_interval))
-                {
+
+                $time_interval = $fd * 1000000;
+                if (!event_add($event, $time_interval)) {
                     return false;
                 }
                 $this->_eventTimer[$timer_id] = array($func, (array)$args, $event, $flag, $time_interval);
                 return $timer_id;
-                
+
             default :
-                $fd_key = (int)$fd;
+                $fd_key    = (int)$fd;
                 $real_flag = $flag === self::EV_READ ? EV_READ | EV_PERSIST : EV_WRITE | EV_PERSIST;
-                
+
                 $event = event_new();
-                
-                if(!event_set($event, $fd, $real_flag, $func, null))
-                {
+
+                if (!event_set($event, $fd, $real_flag, $func, null)) {
                     return false;
                 }
-                
-                if(!event_base_set($event, $this->_eventBase))
-                {
+
+                if (!event_base_set($event, $this->_eventBase)) {
                     return false;
                 }
-                
-                if(!event_add($event))
-                {
+
+                if (!event_add($event)) {
                     return false;
                 }
-                
+
                 $this->_allEvents[$fd_key][$flag] = $event;
-                
+
                 return true;
         }
-        
+
     }
-    
+
     /**
      * {@inheritdoc}
      */
-    public function del($fd ,$flag)
+    public function del($fd, $flag)
     {
-        switch($flag)
-        {
+        switch ($flag) {
             case self::EV_READ:
             case self::EV_WRITE:
                 $fd_key = (int)$fd;
-                if(isset($this->_allEvents[$fd_key][$flag]))
-                {
+                if (isset($this->_allEvents[$fd_key][$flag])) {
                     event_del($this->_allEvents[$fd_key][$flag]);
                     unset($this->_allEvents[$fd_key][$flag]);
                 }
-                if(empty($this->_allEvents[$fd_key]))
-                {
+                if (empty($this->_allEvents[$fd_key])) {
                     unset($this->_allEvents[$fd_key]);
                 }
                 break;
             case  self::EV_SIGNAL:
                 $fd_key = (int)$fd;
-                if(isset($this->_eventSignal[$fd_key]))
-                {
+                if (isset($this->_eventSignal[$fd_key])) {
                     event_del($this->_eventSignal[$fd_key]);
                     unset($this->_eventSignal[$fd_key]);
                 }
@@ -156,8 +146,7 @@ class Libevent implements EventInterface
             case self::EV_TIMER:
             case self::EV_TIMER_ONCE:
                 // 这里 fd 为timerid 
-                if(isset($this->_eventTimer[$fd]))
-                {
+                if (isset($this->_eventTimer[$fd])) {
                     event_del($this->_eventTimer[$fd][2]);
                     unset($this->_eventTimer[$fd]);
                 }
@@ -165,46 +154,41 @@ class Libevent implements EventInterface
         }
         return true;
     }
-    
+
     /**
      * Timer callback.
+     *
      * @param mixed $_null1
-     * @param int $_null2
+     * @param int   $_null2
      * @param mixed $timer_id
      */
     protected function timerCallback($_null1, $_null2, $timer_id)
     {
-        if($this->_eventTimer[$timer_id][3] === self::EV_TIMER)
-        {
+        if ($this->_eventTimer[$timer_id][3] === self::EV_TIMER) {
             event_add($this->_eventTimer[$timer_id][2], $this->_eventTimer[$timer_id][4]);
         }
-        try 
-        {
+        try {
             call_user_func_array($this->_eventTimer[$timer_id][0], $this->_eventTimer[$timer_id][1]);
-        }
-        catch(\Exception $e)
-        {
+        } catch (\Exception $e) {
             echo $e;
             exit(250);
         }
-        if(isset($this->_eventTimer[$timer_id]) && $this->_eventTimer[$timer_id][3] === self::EV_TIMER_ONCE)
-        {
+        if (isset($this->_eventTimer[$timer_id]) && $this->_eventTimer[$timer_id][3] === self::EV_TIMER_ONCE) {
             $this->del($timer_id, self::EV_TIMER_ONCE);
         }
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function clearAllTimer()
     {
-        foreach($this->_eventTimer as $task_data)
-        {
+        foreach ($this->_eventTimer as $task_data) {
             event_del($task_data[2]);
         }
         $this->_eventTimer = array();
     }
-     
+
     /**
      * {@inheritdoc}
      */

--- a/Events/Select.php
+++ b/Events/Select.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Events;
 
@@ -20,60 +20,69 @@ class Select implements EventInterface
 {
     /**
      * All listeners for read/write event.
+     *
      * @var array
      */
     public $_allEvents = array();
-    
+
     /**
      * Event listeners of signal.
+     *
      * @var array
      */
     public $_signalEvents = array();
-    
+
     /**
      * Fds waiting for read event.
+     *
      * @var array
      */
     protected $_readFds = array();
-    
+
     /**
      * Fds waiting for write event.
+     *
      * @var array
      */
     protected $_writeFds = array();
-    
+
     /**
      * Timer scheduler.
      * {['data':timer_id, 'priority':run_timestamp], ..}
+     *
      * @var \SplPriorityQueue
      */
     protected $_scheduler = null;
-    
+
     /**
      * All timer event listeners.
      * [[func, args, flag, timer_interval], ..]
+     *
      * @var array
      */
     protected $_task = array();
-    
+
     /**
      * Timer id.
+     *
      * @var int
      */
     protected $_timerId = 1;
-    
+
     /**
      * Select timeout.
+     *
      * @var int
      */
     protected $_selectTimeout = 100000000;
 
     /**
      * Paired socket channels
+     *
      * @var array
      */
     protected $channel = array();
-    
+
     /**
      * Construct.
      */
@@ -81,8 +90,7 @@ class Select implements EventInterface
     {
         // Create a pipeline and put into the collection of the read to read the descriptor to avoid empty polling.
         $this->channel = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
-        if($this->channel)
-        {
+        if ($this->channel) {
             stream_set_blocking($this->channel[0], 0);
             $this->_readFds[0] = $this->channel[0];
         }
@@ -90,69 +98,66 @@ class Select implements EventInterface
         $this->_scheduler = new \SplPriorityQueue();
         $this->_scheduler->setExtractFlags(\SplPriorityQueue::EXTR_BOTH);
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function add($fd, $flag, $func, $args = array())
     {
-        switch ($flag)
-        {
+        switch ($flag) {
             case self::EV_READ:
-                $fd_key = (int)$fd;
+                $fd_key                           = (int)$fd;
                 $this->_allEvents[$fd_key][$flag] = array($func, $fd);
-                $this->_readFds[$fd_key] = $fd;
+                $this->_readFds[$fd_key]          = $fd;
                 break;
             case self::EV_WRITE:
-                $fd_key = (int)$fd;
+                $fd_key                           = (int)$fd;
                 $this->_allEvents[$fd_key][$flag] = array($func, $fd);
-                $this->_writeFds[$fd_key] = $fd;
+                $this->_writeFds[$fd_key]         = $fd;
                 break;
             case self::EV_SIGNAL:
-                $fd_key = (int)$fd;
+                $fd_key                              = (int)$fd;
                 $this->_signalEvents[$fd_key][$flag] = array($func, $fd);
                 pcntl_signal($fd, array($this, 'signalHandler'));
                 break;
             case self::EV_TIMER:
             case self::EV_TIMER_ONCE:
-                $run_time = microtime(true)+$fd;
+                $run_time = microtime(true) + $fd;
                 $this->_scheduler->insert($this->_timerId, -$run_time);
                 $this->_task[$this->_timerId] = array($func, (array)$args, $flag, $fd);
                 $this->tick();
                 return $this->_timerId++;
         }
-        
+
         return true;
     }
-    
+
     /**
      * Signal handler.
+     *
      * @param int $signal
      */
     public function signalHandler($signal)
     {
         call_user_func_array($this->_signalEvents[$signal][self::EV_SIGNAL][0], array($signal));
     }
-    
+
     /**
      * {@inheritdoc}
      */
-    public function del($fd ,$flag)
+    public function del($fd, $flag)
     {
         $fd_key = (int)$fd;
-        switch ($flag)
-        {
+        switch ($flag) {
             case self::EV_READ:
                 unset($this->_allEvents[$fd_key][$flag], $this->_readFds[$fd_key]);
-                if(empty($this->_allEvents[$fd_key]))
-                {
+                if (empty($this->_allEvents[$fd_key])) {
                     unset($this->_allEvents[$fd_key]);
                 }
                 return true;
             case self::EV_WRITE:
                 unset($this->_allEvents[$fd_key][$flag], $this->_writeFds[$fd_key]);
-                if(empty($this->_allEvents[$fd_key]))
-                {
+                if (empty($this->_allEvents[$fd_key])) {
                     unset($this->_allEvents[$fd_key]);
                 }
                 return true;
@@ -167,51 +172,45 @@ class Select implements EventInterface
         }
         return false;
     }
-    
+
     /**
      * Tick for timer.
+     *
      * @return void
      */
     protected function tick()
     {
-        while(!$this->_scheduler->isEmpty())
-        {
+        while (!$this->_scheduler->isEmpty()) {
             $scheduler_data = $this->_scheduler->top();
-            $timer_id = $scheduler_data['data'];
-            $next_run_time = -$scheduler_data['priority'];
-            $time_now = microtime(true);
-            if($time_now >= $next_run_time)
-            {
+            $timer_id       = $scheduler_data['data'];
+            $next_run_time  = -$scheduler_data['priority'];
+            $time_now       = microtime(true);
+            if ($time_now >= $next_run_time) {
                 $this->_scheduler->extract();
-                
-                if(!isset($this->_task[$timer_id]))
-                {
+
+                if (!isset($this->_task[$timer_id])) {
                     continue;
                 }
-                
+
                 // [func, args, flag, timer_interval]
                 $task_data = $this->_task[$timer_id];
-                if($task_data[2] === self::EV_TIMER)
-                {
-                    $next_run_time = $time_now+$task_data[3];
+                if ($task_data[2] === self::EV_TIMER) {
+                    $next_run_time = $time_now + $task_data[3];
                     $this->_scheduler->insert($timer_id, -$next_run_time);
                 }
                 call_user_func_array($task_data[0], $task_data[1]);
-                if(isset($this->_task[$timer_id]) && $task_data[2] === self::EV_TIMER_ONCE)
-                {
+                if (isset($this->_task[$timer_id]) && $task_data[2] === self::EV_TIMER_ONCE) {
                     $this->del($timer_id, self::EV_TIMER_ONCE);
                 }
                 continue;
-            }
-            else
-            {
-                $this->_selectTimeout = ($next_run_time - $time_now)*1000000;
+            } else {
+                $this->_selectTimeout = ($next_run_time - $time_now) * 1000000;
                 return;
             }
         }
         $this->_selectTimeout = 100000000;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -221,48 +220,43 @@ class Select implements EventInterface
         $this->_scheduler->setExtractFlags(\SplPriorityQueue::EXTR_BOTH);
         $this->_task = array();
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function loop()
     {
         $e = null;
-        while (1)
-        {
+        while (1) {
             // Calls signal handlers for pending signals
             pcntl_signal_dispatch();
-            
-            $read = $this->_readFds;
+
+            $read  = $this->_readFds;
             $write = $this->_writeFds;
             // Waiting read/write/signal/timeout events.
             $ret = @stream_select($read, $write, $e, 0, $this->_selectTimeout);
-            
-            if(!$this->_scheduler->isEmpty())
-            {
+
+            if (!$this->_scheduler->isEmpty()) {
                 $this->tick();
             }
-            
-            if(!$ret)
-            {
+
+            if (!$ret) {
                 continue;
             }
-            
-            foreach($read as $fd)
-            {
-                $fd_key = (int) $fd;
-                if(isset($this->_allEvents[$fd_key][self::EV_READ]))
-                {
-                    call_user_func_array($this->_allEvents[$fd_key][self::EV_READ][0], array($this->_allEvents[$fd_key][self::EV_READ][1]));
+
+            foreach ($read as $fd) {
+                $fd_key = (int)$fd;
+                if (isset($this->_allEvents[$fd_key][self::EV_READ])) {
+                    call_user_func_array($this->_allEvents[$fd_key][self::EV_READ][0],
+                        array($this->_allEvents[$fd_key][self::EV_READ][1]));
                 }
             }
-            
-            foreach($write as $fd)
-            {
-                $fd_key = (int) $fd;
-                if(isset($this->_allEvents[$fd_key][self::EV_WRITE]))
-                {
-                    call_user_func_array($this->_allEvents[$fd_key][self::EV_WRITE][0], array($this->_allEvents[$fd_key][self::EV_WRITE][1]));
+
+            foreach ($write as $fd) {
+                $fd_key = (int)$fd;
+                if (isset($this->_allEvents[$fd_key][self::EV_WRITE])) {
+                    call_user_func_array($this->_allEvents[$fd_key][self::EV_WRITE][0],
+                        array($this->_allEvents[$fd_key][self::EV_WRITE][1]));
                 }
             }
         }

--- a/Lib/Constants.php
+++ b/Lib/Constants.php
@@ -6,15 +6,14 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
 // Date.timezone
-if(!ini_get('date.timezone') )
-{
+if (!ini_get('date.timezone')) {
     date_default_timezone_set('Asia/Shanghai');
 }
 // Display errors.

--- a/Lib/Timer.php
+++ b/Lib/Timer.php
@@ -6,146 +6,137 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Lib;
+
 use Workerman\Events\EventInterface;
 use Exception;
 
 /**
  * Timer.
- * 
+ *
  * example:
  * Workerman\Lib\Timer::add($time_interval, callback, array($arg1, $arg2..));
  */
-class Timer 
+class Timer
 {
     /**
      * Tasks that based on ALARM signal.
      * [
      *   run_time => [[$func, $args, $persistent, time_interval],[$func, $args, $persistent, time_interval],..]],
      *   run_time => [[$func, $args, $persistent, time_interval],[$func, $args, $persistent, time_interval],..]],
-     *   .. 
+     *   ..
      * ]
+     *
      * @var array
      */
     protected static $_tasks = array();
-    
+
     /**
      * event
-     * @var event
+     *
+     * @var \Workerman\Events\EventInterface
      */
     protected static $_event = null;
-    
-    
+
     /**
      * Init.
+     *
+     * @param \Workerman\Events\EventInterface $event
      * @return void
      */
     public static function init($event = null)
     {
-        if($event)
-        {
+        if ($event) {
             self::$_event = $event;
-        }
-        else 
-        {
+        } else {
             pcntl_signal(SIGALRM, array('\Workerman\Lib\Timer', 'signalHandle'), false);
         }
     }
-    
+
     /**
      * ALARM signal handler.
+     *
      * @return void
      */
     public static function signalHandle()
     {
-        if(!self::$_event)
-        {
+        if (!self::$_event) {
             pcntl_alarm(1);
             self::tick();
         }
     }
-    
-    
+
     /**
      * Add a timer.
-     * @param int $time_interval
+     *
+     * @param int      $time_interval
      * @param callback $func
-     * @param mix $args
-     * @return void
+     * @param mixed    $args
+     * @param bool     $persistent
+     * @return bool
      */
     public static function add($time_interval, $func, $args = array(), $persistent = true)
     {
-        if($time_interval <= 0)
-        {
+        if ($time_interval <= 0) {
             echo new Exception("bad time_interval");
             return false;
         }
-        
-        if(self::$_event)
-        {
-            return self::$_event->add($time_interval, $persistent ? EventInterface::EV_TIMER : EventInterface::EV_TIMER_ONCE , $func, $args);
+
+        if (self::$_event) {
+            return self::$_event->add($time_interval,
+                $persistent ? EventInterface::EV_TIMER : EventInterface::EV_TIMER_ONCE, $func, $args);
         }
-        
-        if(!is_callable($func))
-        {
+
+        if (!is_callable($func)) {
             echo new Exception("not callable");
             return false;
         }
-        
-        if(empty(self::$_tasks))
-        {
+
+        if (empty(self::$_tasks)) {
             pcntl_alarm(1);
         }
-        
+
         $time_now = time();
         $run_time = $time_now + $time_interval;
-        if(!isset(self::$_tasks[$run_time]))
-        {
+        if (!isset(self::$_tasks[$run_time])) {
             self::$_tasks[$run_time] = array();
         }
         self::$_tasks[$run_time][] = array($func, (array)$args, $persistent, $time_interval);
         return true;
     }
-    
-    
+
+
     /**
      * Tick.
+     *
      * @return void
      */
     public static function tick()
     {
-        if(empty(self::$_tasks))
-        {
+        if (empty(self::$_tasks)) {
             pcntl_alarm(0);
             return;
         }
-        
+
         $time_now = time();
-        foreach (self::$_tasks as $run_time=>$task_data)
-        {
-            if($time_now >= $run_time)
-            {
-                foreach($task_data as $index=>$one_task)
-                {
-                    $task_func = $one_task[0];
-                    $task_args = $one_task[1];
-                    $persistent = $one_task[2];
+        foreach (self::$_tasks as $run_time => $task_data) {
+            if ($time_now >= $run_time) {
+                foreach ($task_data as $index => $one_task) {
+                    $task_func     = $one_task[0];
+                    $task_args     = $one_task[1];
+                    $persistent    = $one_task[2];
                     $time_interval = $one_task[3];
-                    try 
-                    {
+                    try {
                         call_user_func_array($task_func, $task_args);
-                    }
-                    catch(\Exception $e)
-                    {
+                    } catch (\Exception $e) {
                         echo $e;
                     }
-                    if($persistent)
-                    {
+                    if ($persistent) {
                         self::add($time_interval, $task_func, $task_args);
                     }
                 }
@@ -153,29 +144,32 @@ class Timer
             }
         }
     }
-    
+
     /**
      * Remove a timer.
-     * @param $timer_id
+     *
+     * @param mixed $timer_id
+     * @return bool
      */
     public static function del($timer_id)
     {
-        if(self::$_event)
-        {
+        if (self::$_event) {
             return self::$_event->del($timer_id, EventInterface::EV_TIMER);
         }
+
+        return false;
     }
-    
+
     /**
      * Remove all timers.
+     *
      * @return void
      */
     public static function delAll()
     {
         self::$_tasks = array();
         pcntl_alarm(0);
-        if(self::$_event)
-        {
+        if (self::$_event) {
             self::$_event->clearAllTimer();
         }
     }

--- a/Protocols/Frame.php
+++ b/Protocols/Frame.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of workerman.
  *
@@ -6,12 +6,13 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Protocols;
+
 use Workerman\Connection\TcpConnection;
 
 /**
@@ -21,22 +22,23 @@ class Frame
 {
     /**
      * Check the integrity of the package.
-     * @param string $buffer
+     *
+     * @param string        $buffer
      * @param TcpConnection $connection
      * @return int
      */
-    public static function input($buffer ,TcpConnection $connection)
+    public static function input($buffer, TcpConnection $connection)
     {
-        if(strlen($buffer)<4)
-        {
+        if (strlen($buffer) < 4) {
             return 0;
         }
         $unpack_data = unpack('Ntotal_length', $buffer);
         return $unpack_data['total_length'];
     }
-    
+
     /**
      * Encode.
+     *
      * @param string $buffer
      * @return string
      */
@@ -44,15 +46,16 @@ class Frame
     {
         return substr($buffer, 4);
     }
-    
+
     /**
      * Decode.
+     *
      * @param string $buffer
      * @return string
      */
     public static function encode($buffer)
     {
         $total_length = 4 + strlen($buffer);
-        return pack('N',$total_length) . $buffer;
+        return pack('N', $total_length) . $buffer;
     }
 }

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of workerman.
  *
@@ -6,12 +6,12 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace  Workerman\Protocols;
+namespace Workerman\Protocols;
 
 use Workerman\Connection\TcpConnection;
 
@@ -22,104 +22,95 @@ class Http
 {
     /**
      * Check the integrity of the package.
-     * @param string $recv_buffer
+     *
+     * @param string        $recv_buffer
      * @param TcpConnection $connection
      * @return int
      */
     public static function input($recv_buffer, TcpConnection $connection)
     {
-        if(!strpos($recv_buffer, "\r\n\r\n"))
-        {
+        if (!strpos($recv_buffer, "\r\n\r\n")) {
             // Judge whether the package length exceeds the limit.
-            if(strlen($recv_buffer)>=TcpConnection::$maxPackageSize)
-            {
+            if (strlen($recv_buffer) >= TcpConnection::$maxPackageSize) {
                 $connection->close();
                 return 0;
             }
             return 0;
         }
-        
+
         list($header,) = explode("\r\n\r\n", $recv_buffer, 2);
-        if(0 === strpos($recv_buffer, "POST"))
-        {
+        if (0 === strpos($recv_buffer, "POST")) {
             // find Content-Length
             $match = array();
-            if(preg_match("/\r\nContent-Length: ?(\d+)/", $header, $match))
-            {
+            if (preg_match("/\r\nContent-Length: ?(\d+)/", $header, $match)) {
                 $content_length = $match[1];
                 return $content_length + strlen($header) + 4;
-            }
-            else
-            {
+            } else {
                 return 0;
             }
-        }
-        else
-        {
-            return strlen($header)+4;
+        } else {
+            return strlen($header) + 4;
         }
     }
-    
+
     /**
-     * Parse $_POST、$_GET、$_COOKIE. 
-     * @param string $recv_buffer
+     * Parse $_POST、$_GET、$_COOKIE.
+     *
+     * @param string        $recv_buffer
      * @param TcpConnection $connection
      * @return array
      */
     public static function decode($recv_buffer, TcpConnection $connection)
     {
         // Init.
-        $_POST = $_GET = $_COOKIE = $_REQUEST = $_SESSION = $_FILES =  array();
+        $_POST                         = $_GET = $_COOKIE = $_REQUEST = $_SESSION = $_FILES = array();
         $GLOBALS['HTTP_RAW_POST_DATA'] = '';
         // Clear cache.
-        HttpCache::$header = array('Connection'=>'Connection: keep-alive');
+        HttpCache::$header   = array('Connection' => 'Connection: keep-alive');
         HttpCache::$instance = new HttpCache();
         // $_SERVER
-        $_SERVER = array (
-              'QUERY_STRING' => '',
-              'REQUEST_METHOD' => '',
-              'REQUEST_URI' => '',
-              'SERVER_PROTOCOL' => '',
-              'SERVER_SOFTWARE' => 'workerman/3.0',
-              'SERVER_NAME' => '', 
-              'HTTP_HOST' => '',
-              'HTTP_USER_AGENT' => '',
-              'HTTP_ACCEPT' => '',
-              'HTTP_ACCEPT_LANGUAGE' => '',
-              'HTTP_ACCEPT_ENCODING' => '',
-              'HTTP_COOKIE' => '',
-              'HTTP_CONNECTION' => '',
-              'REMOTE_ADDR' => '',
-              'REMOTE_PORT' => '0',
-           );
-        
+        $_SERVER = array(
+            'QUERY_STRING'         => '',
+            'REQUEST_METHOD'       => '',
+            'REQUEST_URI'          => '',
+            'SERVER_PROTOCOL'      => '',
+            'SERVER_SOFTWARE'      => 'workerman/3.0',
+            'SERVER_NAME'          => '',
+            'HTTP_HOST'            => '',
+            'HTTP_USER_AGENT'      => '',
+            'HTTP_ACCEPT'          => '',
+            'HTTP_ACCEPT_LANGUAGE' => '',
+            'HTTP_ACCEPT_ENCODING' => '',
+            'HTTP_COOKIE'          => '',
+            'HTTP_CONNECTION'      => '',
+            'REMOTE_ADDR'          => '',
+            'REMOTE_PORT'          => '0',
+        );
+
         // Parse headers.
         list($http_header, $http_body) = explode("\r\n\r\n", $recv_buffer, 2);
         $header_data = explode("\r\n", $http_header);
-        
-        list($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['SERVER_PROTOCOL']) = explode(' ', $header_data[0]);
+
+        list($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['SERVER_PROTOCOL']) = explode(' ',
+            $header_data[0]);
 
         $http_post_boundary = '';
         unset($header_data[0]);
-        foreach($header_data as $content)
-        {
+        foreach ($header_data as $content) {
             // \r\n\r\n
-            if(empty($content))
-            {
+            if (empty($content)) {
                 continue;
             }
             list($key, $value) = explode(':', $content, 2);
-            $key = strtolower($key);
+            $key   = strtolower($key);
             $value = trim($value);
-            switch($key)
-            {
+            switch ($key) {
                 // HTTP_HOST
                 case 'host':
-                    $_SERVER['HTTP_HOST'] = $value;
-                    $tmp = explode(':', $value);
+                    $_SERVER['HTTP_HOST']   = $value;
+                    $tmp                    = explode(':', $value);
                     $_SERVER['SERVER_NAME'] = $tmp[0];
-                    if(isset($tmp[1]))
-                    {
+                    if (isset($tmp[1])) {
                         $_SERVER['SERVER_PORT'] = $tmp[1];
                     }
                     break;
@@ -158,324 +149,292 @@ class Http
                     $_SERVER['HTTP_IF_NONE_MATCH'] = $value;
                     break;
                 case 'content-type':
-                    if(!preg_match('/boundary="?(\S+)"?/', $value, $match))
-                    {
+                    if (!preg_match('/boundary="?(\S+)"?/', $value, $match)) {
                         $_SERVER['CONTENT_TYPE'] = $value;
-                    }
-                    else
-                    {
+                    } else {
                         $_SERVER['CONTENT_TYPE'] = 'multipart/form-data';
-                        $http_post_boundary = '--'.$match[1];
+                        $http_post_boundary      = '--' . $match[1];
                     }
                     break;
             }
         }
-        
+
         // Parse $_POST.
-        if($_SERVER['REQUEST_METHOD'] === 'POST')
-        {
-            if(isset($_SERVER['CONTENT_TYPE']) && $_SERVER['CONTENT_TYPE'] === 'multipart/form-data')
-            {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            if (isset($_SERVER['CONTENT_TYPE']) && $_SERVER['CONTENT_TYPE'] === 'multipart/form-data') {
                 self::parseUploadFiles($http_body, $http_post_boundary);
-            }
-            else
-            {
+            } else {
                 parse_str($http_body, $_POST);
                 // $GLOBALS['HTTP_RAW_POST_DATA']
                 $GLOBALS['HTTP_RAW_POST_DATA'] = $http_body;
             }
         }
-        
+
         // QUERY_STRING
         $_SERVER['QUERY_STRING'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
-        if($_SERVER['QUERY_STRING'])
-        {
+        if ($_SERVER['QUERY_STRING']) {
             // $GET
             parse_str($_SERVER['QUERY_STRING'], $_GET);
-        }
-        else
-        {
+        } else {
             $_SERVER['QUERY_STRING'] = '';
         }
-        
+
         // REQUEST
         $_REQUEST = array_merge($_GET, $_POST);
-        
+
         // REMOTE_ADDR REMOTE_PORT
         $_SERVER['REMOTE_ADDR'] = $connection->getRemoteIp();
         $_SERVER['REMOTE_PORT'] = $connection->getRemotePort();
-        
-        return array('get'=>$_GET, 'post'=>$_POST, 'cookie'=>$_COOKIE, 'server'=>$_SERVER, 'files'=>$_FILES);
+
+        return array('get' => $_GET, 'post' => $_POST, 'cookie' => $_COOKIE, 'server' => $_SERVER, 'files' => $_FILES);
     }
-    
+
     /**
      * Http encode.
-     * @param string $content
+     *
+     * @param string        $content
      * @param TcpConnection $connection
      * @return string
      */
     public static function encode($content, TcpConnection $connection)
     {
         // Default http-code.
-        if(!isset(HttpCache::$header['Http-Code']))
-        {
+        if (!isset(HttpCache::$header['Http-Code'])) {
             $header = "HTTP/1.1 200 OK\r\n";
-        }
-        else
-        {
-            $header = HttpCache::$header['Http-Code']."\r\n";
+        } else {
+            $header = HttpCache::$header['Http-Code'] . "\r\n";
             unset(HttpCache::$header['Http-Code']);
         }
-        
+
         // Content-Type
-        if(!isset(HttpCache::$header['Content-Type']))
-        {
+        if (!isset(HttpCache::$header['Content-Type'])) {
             $header .= "Content-Type: text/html;charset=utf-8\r\n";
         }
-        
+
         // other headers
-        foreach(HttpCache::$header as $key=>$item)
-        {
-            if('Set-Cookie' === $key && is_array($item))
-            {
-                foreach($item as $it)
-                {
-                    $header .= $it."\r\n";
+        foreach (HttpCache::$header as $key => $item) {
+            if ('Set-Cookie' === $key && is_array($item)) {
+                foreach ($item as $it) {
+                    $header .= $it . "\r\n";
                 }
-            }
-            else
-            {
-                $header .= $item."\r\n";
+            } else {
+                $header .= $item . "\r\n";
             }
         }
-         
+
         // header
-        $header .= "Server: WorkerMan/3.0\r\nContent-Length: ".strlen($content)."\r\n\r\n";
-        
+        $header .= "Server: WorkerMan/3.0\r\nContent-Length: " . strlen($content) . "\r\n\r\n";
+
         // save session
         self::sessionWriteClose();
-        
+
         // the whole http package
-        return $header.$content;
+        return $header . $content;
     }
-    
+
     /**
      * 设置http头
+     *
      * @return bool|void
      */
     public static function header($content, $replace = true, $http_response_code = 0)
     {
-        if(PHP_SAPI != 'cli')
-        {
+        if (PHP_SAPI != 'cli') {
             return $http_response_code ? header($content, $replace, $http_response_code) : header($content, $replace);
         }
-        if(strpos($content, 'HTTP') === 0)
-        {
+        if (strpos($content, 'HTTP') === 0) {
             $key = 'Http-Code';
-        }
-        else
-        {
+        } else {
             $key = strstr($content, ":", true);
-            if(empty($key))
-            {
+            if (empty($key)) {
                 return false;
             }
         }
-    
-        if('location' === strtolower($key) && !$http_response_code)
-        {
+
+        if ('location' === strtolower($key) && !$http_response_code) {
             return self::header($content, true, 302);
         }
-    
-        if(isset(HttpCache::$codes[$http_response_code]))
-        {
-            HttpCache::$header['Http-Code'] = "HTTP/1.1 $http_response_code " .  HttpCache::$codes[$http_response_code];
-            if($key === 'Http-Code')
-            {
+
+        if (isset(HttpCache::$codes[$http_response_code])) {
+            HttpCache::$header['Http-Code'] = "HTTP/1.1 $http_response_code " . HttpCache::$codes[$http_response_code];
+            if ($key === 'Http-Code') {
                 return true;
             }
         }
-    
-        if($key === 'Set-Cookie')
-        {
+
+        if ($key === 'Set-Cookie') {
             HttpCache::$header[$key][] = $content;
-        }
-        else
-        {
+        } else {
             HttpCache::$header[$key] = $content;
         }
-    
+
         return true;
     }
-    
+
     /**
      * Remove header.
+     *
      * @param string $name
      * @return void
      */
     public static function headerRemove($name)
     {
-        if(PHP_SAPI != 'cli')
-        {
+        if (PHP_SAPI != 'cli') {
             header_remove($name);
             return;
         }
-        unset( HttpCache::$header[$name]);
+        unset(HttpCache::$header[$name]);
     }
-    
+
     /**
      * Set cookie.
-     * @param string $name
-     * @param string $value
+     *
+     * @param string  $name
+     * @param string  $value
      * @param integer $maxage
-     * @param string $path
-     * @param string $domain
-     * @param bool $secure
-     * @param bool $HTTPOnly
+     * @param string  $path
+     * @param string  $domain
+     * @param bool    $secure
+     * @param bool    $HTTPOnly
      * @return bool|void
      */
-    public static function setcookie($name, $value = '', $maxage = 0, $path = '', $domain = '', $secure = false, $HTTPOnly = false) {
-        if(PHP_SAPI != 'cli')
-        {
+    public static function setcookie(
+        $name,
+        $value = '',
+        $maxage = 0,
+        $path = '',
+        $domain = '',
+        $secure = false,
+        $HTTPOnly = false
+    ) {
+        if (PHP_SAPI != 'cli') {
             return setcookie($name, $value, $maxage, $path, $domain, $secure, $HTTPOnly);
         }
         return self::header(
-                'Set-Cookie: ' . $name . '=' . rawurlencode($value)
-                . (empty($domain) ? '' : '; Domain=' . $domain)
-                . (empty($maxage) ? '' : '; Max-Age=' . $maxage)
-                . (empty($path) ? '' : '; Path=' . $path)
-                . (!$secure ? '' : '; Secure')
-                . (!$HTTPOnly ? '' : '; HttpOnly'), false);
+            'Set-Cookie: ' . $name . '=' . rawurlencode($value)
+            . (empty($domain) ? '' : '; Domain=' . $domain)
+            . (empty($maxage) ? '' : '; Max-Age=' . $maxage)
+            . (empty($path) ? '' : '; Path=' . $path)
+            . (!$secure ? '' : '; Secure')
+            . (!$HTTPOnly ? '' : '; HttpOnly'), false);
     }
-    
+
     /**
      * sessionStart
+     *
      * @return bool
      */
     public static function sessionStart()
     {
-        if(PHP_SAPI != 'cli')
-        {
+        if (PHP_SAPI != 'cli') {
             return session_start();
         }
-        if(HttpCache::$instance->sessionStarted)
-        {
+        if (HttpCache::$instance->sessionStarted) {
             echo "already sessionStarted\nn";
             return true;
         }
         HttpCache::$instance->sessionStarted = true;
         // Generate a SID.
-        if(!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName]))
-        {
+        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName])) {
             $file_name = tempnam(HttpCache::$sessionPath, 'ses');
-            if(!$file_name)
-            {
+            if (!$file_name) {
                 return false;
             }
             HttpCache::$instance->sessionFile = $file_name;
-            $session_id = substr(basename($file_name), strlen('ses'));
+            $session_id                       = substr(basename($file_name), strlen('ses'));
             return self::setcookie(
-                    HttpCache::$sessionName
-                    , $session_id
-                    , ini_get('session.cookie_lifetime')
-                    , ini_get('session.cookie_path')
-                    , ini_get('session.cookie_domain')
-                    , ini_get('session.cookie_secure')
-                    , ini_get('session.cookie_httponly')
+                HttpCache::$sessionName
+                , $session_id
+                , ini_get('session.cookie_lifetime')
+                , ini_get('session.cookie_path')
+                , ini_get('session.cookie_domain')
+                , ini_get('session.cookie_secure')
+                , ini_get('session.cookie_httponly')
             );
         }
-        if(!HttpCache::$instance->sessionFile)
-        {
+        if (!HttpCache::$instance->sessionFile) {
             HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName];
         }
         // Read session from session file.
-        if(HttpCache::$instance->sessionFile)
-        {
+        if (HttpCache::$instance->sessionFile) {
             $raw = file_get_contents(HttpCache::$instance->sessionFile);
-            if($raw)
-            {
+            if ($raw) {
                 session_decode($raw);
             }
         }
     }
-    
+
     /**
      * Save session.
+     *
      * @return bool
      */
     public static function sessionWriteClose()
     {
-        if(PHP_SAPI != 'cli')
-        {
+        if (PHP_SAPI != 'cli') {
             return session_write_close();
         }
-        if(!empty(HttpCache::$instance->sessionStarted) && !empty($_SESSION))
-        {
+        if (!empty(HttpCache::$instance->sessionStarted) && !empty($_SESSION)) {
             $session_str = session_encode();
-            if($session_str && HttpCache::$instance->sessionFile)
-            {
+            if ($session_str && HttpCache::$instance->sessionFile) {
                 return file_put_contents(HttpCache::$instance->sessionFile, $session_str);
             }
         }
         return empty($_SESSION);
     }
-    
+
     /**
      * End, like call exit in php-fpm.
+     *
      * @param string $msg
      * @throws \Exception
      */
     public static function end($msg = '')
     {
-        if(PHP_SAPI != 'cli')
-        {
+        if (PHP_SAPI != 'cli') {
             exit($msg);
         }
-        if($msg)
-        {
+        if ($msg) {
             echo $msg;
         }
         throw new \Exception('jump_exit');
     }
-    
+
     /**
      * Get mime types.
+     *
      * @return string
      */
     public static function getMimeTypesFile()
     {
-        return __DIR__.'/Http/mime.types';
+        return __DIR__ . '/Http/mime.types';
     }
-    
-     /**
+
+    /**
      * Parse $_FILES.
-      * @param string $http_body
-      * @param string $http_post_boundary
+     *
+     * @param string $http_body
+     * @param string $http_post_boundary
      * @return void
      */
     protected static function parseUploadFiles($http_body, $http_post_boundary)
     {
-        $http_body = substr($http_body, 0, strlen($http_body) - (strlen($http_post_boundary) + 4));
-        $boundary_data_array = explode($http_post_boundary."\r\n", $http_body);
-        if($boundary_data_array[0] === '')
-        {
+        $http_body           = substr($http_body, 0, strlen($http_body) - (strlen($http_post_boundary) + 4));
+        $boundary_data_array = explode($http_post_boundary . "\r\n", $http_body);
+        if ($boundary_data_array[0] === '') {
             unset($boundary_data_array[0]);
         }
-        foreach($boundary_data_array as $boundary_data_buffer)
-        {
+        foreach ($boundary_data_array as $boundary_data_buffer) {
             list($boundary_header_buffer, $boundary_value) = explode("\r\n\r\n", $boundary_data_buffer, 2);
             // Remove \r\n from the end of buffer.
             $boundary_value = substr($boundary_value, 0, -2);
-            foreach (explode("\r\n", $boundary_header_buffer) as $item)
-            {
+            foreach (explode("\r\n", $boundary_header_buffer) as $item) {
                 list($header_key, $header_value) = explode(": ", $item);
                 $header_key = strtolower($header_key);
-                switch ($header_key)
-                {
+                switch ($header_key) {
                     case "content-disposition":
                         // Is file data.
-                        if(preg_match('/name=".*?"; filename="(.*?)"$/', $header_value, $match))
-                        {
+                        if (preg_match('/name=".*?"; filename="(.*?)"$/', $header_value, $match)) {
                             // Parse $_FILES.
                             $_FILES[] = array(
                                 'file_name' => $match[1],
@@ -483,13 +442,10 @@ class Http
                                 'file_size' => strlen($boundary_value),
                             );
                             continue;
-                        }
-                        // Is post field.
-                        else
-                        {
+                        } // Is post field.
+                        else {
                             // Parse $_POST.
-                            if(preg_match('/name="(.*?)"$/', $header_value, $match))
-                            {
+                            if (preg_match('/name="(.*?)"$/', $header_value, $match)) {
                                 $_POST[$match[1]] = $boundary_value;
                             }
                         }
@@ -506,50 +462,50 @@ class Http
 class HttpCache
 {
     public static $codes = array(
-            100 => 'Continue',
-            101 => 'Switching Protocols',
-            200 => 'OK',
-            201 => 'Created',
-            202 => 'Accepted',
-            203 => 'Non-Authoritative Information',
-            204 => 'No Content',
-            205 => 'Reset Content',
-            206 => 'Partial Content',
-            300 => 'Multiple Choices',
-            301 => 'Moved Permanently',
-            302 => 'Found',
-            303 => 'See Other',
-            304 => 'Not Modified',
-            305 => 'Use Proxy',
-            306 => '(Unused)',
-            307 => 'Temporary Redirect',
-            400 => 'Bad Request',
-            401 => 'Unauthorized',
-            402 => 'Payment Required',
-            403 => 'Forbidden',
-            404 => 'Not Found',
-            405 => 'Method Not Allowed',
-            406 => 'Not Acceptable',
-            407 => 'Proxy Authentication Required',
-            408 => 'Request Timeout',
-            409 => 'Conflict',
-            410 => 'Gone',
-            411 => 'Length Required',
-            412 => 'Precondition Failed',
-            413 => 'Request Entity Too Large',
-            414 => 'Request-URI Too Long',
-            415 => 'Unsupported Media Type',
-            416 => 'Requested Range Not Satisfiable',
-            417 => 'Expectation Failed',
-            422 => 'Unprocessable Entity',
-            423 => 'Locked',
-            500 => 'Internal Server Error',
-            501 => 'Not Implemented',
-            502 => 'Bad Gateway',
-            503 => 'Service Unavailable',
-            504 => 'Gateway Timeout',
-            505 => 'HTTP Version Not Supported',
-      );
+        100 => 'Continue',
+        101 => 'Switching Protocols',
+        200 => 'OK',
+        201 => 'Created',
+        202 => 'Accepted',
+        203 => 'Non-Authoritative Information',
+        204 => 'No Content',
+        205 => 'Reset Content',
+        206 => 'Partial Content',
+        300 => 'Multiple Choices',
+        301 => 'Moved Permanently',
+        302 => 'Found',
+        303 => 'See Other',
+        304 => 'Not Modified',
+        305 => 'Use Proxy',
+        306 => '(Unused)',
+        307 => 'Temporary Redirect',
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        402 => 'Payment Required',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        405 => 'Method Not Allowed',
+        406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
+        408 => 'Request Timeout',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'Length Required',
+        412 => 'Precondition Failed',
+        413 => 'Request Entity Too Large',
+        414 => 'Request-URI Too Long',
+        415 => 'Unsupported Media Type',
+        416 => 'Requested Range Not Satisfiable',
+        417 => 'Expectation Failed',
+        422 => 'Unprocessable Entity',
+        423 => 'Locked',
+        500 => 'Internal Server Error',
+        501 => 'Not Implemented',
+        502 => 'Bad Gateway',
+        503 => 'Service Unavailable',
+        504 => 'Gateway Timeout',
+        505 => 'HTTP Version Not Supported',
+    );
 
     /**
      * @var HttpCache
@@ -566,8 +522,7 @@ class HttpCache
     {
         self::$sessionName = ini_get('session.name');
         self::$sessionPath = session_save_path();
-        if(!self::$sessionPath)
-        {
+        if (!self::$sessionPath) {
             self::$sessionPath = sys_get_temp_dir();
         }
         @\session_start();

--- a/Protocols/ProtocolInterface.php
+++ b/Protocols/ProtocolInterface.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Protocols;
 
@@ -25,27 +25,27 @@ interface ProtocolInterface
      * Please return the length of package.
      * If length is unknow please return 0 that mean wating more data.
      * If the package has something wrong please return false the connection will be closed.
-     * 
+     *
      * @param ConnectionInterface $connection
-     * @param string $recv_buffer
+     * @param string              $recv_buffer
      * @return int|false
      */
     public static function input($recv_buffer, ConnectionInterface $connection);
-    
+
     /**
      * Decode package and emit onMessage($message) callback, $message is the result that decode returned.
-     * 
+     *
      * @param ConnectionInterface $connection
-     * @param string $recv_buffer
+     * @param string              $recv_buffer
      * @return mixed
      */
     public static function decode($recv_buffer, ConnectionInterface $connection);
-    
+
     /**
      * Encode package brefore sending to client.
-     * 
+     *
      * @param ConnectionInterface $connection
-     * @param mixed $data
+     * @param mixed               $data
      * @return string
      */
     public static function encode($data, ConnectionInterface $connection);

--- a/Protocols/Text.php
+++ b/Protocols/Text.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of workerman.
  *
@@ -6,12 +6,13 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Protocols;
+
 use Workerman\Connection\TcpConnection;
 
 /**
@@ -21,42 +22,43 @@ class Text
 {
     /**
      * Check the integrity of the package.
-     * @param string $buffer
+     *
+     * @param string        $buffer
      * @param TcpConnection $connection
      * @return int
      */
-    public static function input($buffer ,TcpConnection $connection)
+    public static function input($buffer, TcpConnection $connection)
     {
         // Judge whether the package length exceeds the limit.
-        if(strlen($buffer)>=TcpConnection::$maxPackageSize)
-        {
+        if (strlen($buffer) >= TcpConnection::$maxPackageSize) {
             $connection->close();
             return 0;
         }
         //  Find the position of  "\n".
         $pos = strpos($buffer, "\n");
         // No "\n", packet length is unknown, continue to wait for the data so return 0.
-        if($pos === false)
-        {
+        if ($pos === false) {
             return 0;
         }
         // Return the current package length.
-        return $pos+1;
+        return $pos + 1;
     }
-    
+
     /**
      * Encode.
+     *
      * @param string $buffer
      * @return string
      */
     public static function encode($buffer)
     {
         // Add "\n"
-        return $buffer."\n";
+        return $buffer . "\n";
     }
-    
+
     /**
      * Decode.
+     *
      * @param string $buffer
      * @return string
      */

--- a/Protocols/Websocket.php
+++ b/Protocols/Websocket.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of workerman.
  *
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman\Protocols;
 
@@ -22,25 +22,29 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
 {
     /**
      * Minimum head length of websocket protocol.
+     *
      * @var int
      */
     const MIN_HEAD_LEN = 6;
-    
+
     /**
      * Websocket blob type.
+     *
      * @var string
      */
     const BINARY_TYPE_BLOB = "\x81";
 
     /**
      * Websocket arraybuffer type.
+     *
      * @var string
      */
     const BINARY_TYPE_ARRAYBUFFER = "\x82";
-    
+
     /**
      * Check the integrity of the package.
-     * @param string $buffer
+     *
+     * @param string              $buffer
      * @param ConnectionInterface $connection
      * @return int
      */
@@ -49,35 +53,28 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
         // Receive length.
         $recv_len = strlen($buffer);
         // We need more data.
-        if($recv_len < self::MIN_HEAD_LEN)
-        {
+        if ($recv_len < self::MIN_HEAD_LEN) {
             return 0;
         }
-        
+
         // Has not yet completed the handshake.
-        if(empty($connection->websocketHandshake))
-        {
+        if (empty($connection->websocketHandshake)) {
             return self::dealHandshake($buffer, $connection);
         }
-        
+
         // Buffer websocket frame data.
-        if($connection->websocketCurrentFrameLength)
-        {
+        if ($connection->websocketCurrentFrameLength) {
             // We need more frame data.
-            if($connection->websocketCurrentFrameLength > $recv_len)
-            {
+            if ($connection->websocketCurrentFrameLength > $recv_len) {
                 // Return 0, because it is not clear the full packet length, waiting for the frame of fin=1.
                 return 0;
             }
-        }
-        else 
-        {
-            $data_len = ord($buffer[1]) & 127;
-            $firstbyte = ord($buffer[0]);
-            $is_fin_frame = $firstbyte>>7;
-            $opcode = $firstbyte & 0xf;
-            switch($opcode)
-            {
+        } else {
+            $data_len     = ord($buffer[1]) & 127;
+            $firstbyte    = ord($buffer[0]);
+            $is_fin_frame = $firstbyte >> 7;
+            $opcode       = $firstbyte & 0xf;
+            switch ($opcode) {
                 case 0x0:
                     break;
                 // Blob type.
@@ -89,47 +86,34 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
                 // Close package.
                 case 0x8:
                     // Try to emit onWebSocketClose callback.
-                    if(isset($connection->onWebSocketClose))
-                    {
-                        try 
-                        {
+                    if (isset($connection->onWebSocketClose)) {
+                        try {
                             call_user_func($connection->onWebSocketClose, $connection);
-                        }
-                        catch(\Exception $e)
-                        {
+                        } catch (\Exception $e) {
                             echo $e;
                             exit(250);
                         }
-                    }
-                    // Close connection.
-                    else
-                    {
+                    } // Close connection.
+                    else {
                         $connection->close();
                     }
                     return 0;
                 // Ping package.
                 case 0x9:
                     // Try to emit onWebSocketPing callback.
-                    if(isset($connection->onWebSocketPing))
-                    {
-                        try 
-                        {
+                    if (isset($connection->onWebSocketPing)) {
+                        try {
                             call_user_func($connection->onWebSocketPing, $connection);
-                        }
-                        catch(\Exception $e)
-                        {
+                        } catch (\Exception $e) {
                             echo $e;
                             exit(250);
                         }
-                    }
-                    // Send pong package to client.
-                    else 
-                    {
+                    } // Send pong package to client.
+                    else {
                         $connection->send(pack('H*', '8a00'), true);
                     }
                     // Consume data from receive buffer.
-                    if(!$data_len)
-                    {
+                    if (!$data_len) {
                         $connection->consumeRecvBuffer(self::MIN_HEAD_LEN);
                         return 0;
                     }
@@ -137,21 +121,16 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
                 // Pong package.
                 case 0xa:
                     // Try to emit onWebSocketPong callback.
-                    if(isset($connection->onWebSocketPong))
-                    {
-                        try
-                        {
+                    if (isset($connection->onWebSocketPong)) {
+                        try {
                             call_user_func($connection->onWebSocketPong, $connection);
-                        }
-                        catch(\Exception $e)
-                        {
+                        } catch (\Exception $e) {
                             echo $e;
                             exit(250);
                         }
                     }
                     //  Consume data from receive buffer.
-                    if(!$data_len)
-                    {
+                    if (!$data_len) {
                         $connection->consumeRecvBuffer(self::MIN_HEAD_LEN);
                         return 0;
                     }
@@ -162,109 +141,97 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
                     $connection->close();
                     return 0;
             }
-            
+
             // Calculate packet length.
             $head_len = self::MIN_HEAD_LEN;
             if ($data_len === 126) {
                 $head_len = 8;
-                if($head_len > $recv_len)
-                {
+                if ($head_len > $recv_len) {
                     return 0;
                 }
-                $pack = unpack('ntotal_len', substr($buffer, 2, 2));
+                $pack     = unpack('ntotal_len', substr($buffer, 2, 2));
                 $data_len = $pack['total_len'];
-            } else if ($data_len === 127) {
-                $head_len = 14;
-                if($head_len > $recv_len)
-                {
-                    return 0;
+            } else {
+                if ($data_len === 127) {
+                    $head_len = 14;
+                    if ($head_len > $recv_len) {
+                        return 0;
+                    }
+                    $arr      = unpack('N2', substr($buffer, 2, 8));
+                    $data_len = $arr[1] * 4294967296 + $arr[2];
                 }
-                $arr = unpack('N2', substr($buffer, 2, 8));
-                $data_len = $arr[1]*4294967296 + $arr[2];
             }
             $current_frame_length = $head_len + $data_len;
-            if($is_fin_frame)
-            {
+            if ($is_fin_frame) {
                 return $current_frame_length;
-            }
-            else
-            {
+            } else {
                 $connection->websocketCurrentFrameLength = $current_frame_length;
             }
         }
-        
+
         // Received just a frame length data.
-        if($connection->websocketCurrentFrameLength == $recv_len)
-        {
+        if ($connection->websocketCurrentFrameLength == $recv_len) {
             self::decode($buffer, $connection);
             $connection->consumeRecvBuffer($connection->websocketCurrentFrameLength);
             $connection->websocketCurrentFrameLength = 0;
             return 0;
-        }
-        // The length of the received data is greater than the length of a frame.
-        elseif($connection->websocketCurrentFrameLength < $recv_len)
-        {
+        } // The length of the received data is greater than the length of a frame.
+        elseif ($connection->websocketCurrentFrameLength < $recv_len) {
             self::decode(substr($buffer, 0, $connection->websocketCurrentFrameLength), $connection);
             $connection->consumeRecvBuffer($connection->websocketCurrentFrameLength);
-            $current_frame_length = $connection->websocketCurrentFrameLength;
+            $current_frame_length                    = $connection->websocketCurrentFrameLength;
             $connection->websocketCurrentFrameLength = 0;
             // Continue to read next frame.
             return self::input(substr($buffer, $current_frame_length), $connection);
-        }
-        // The length of the received data is less than the length of a frame.
-        else
-        {
+        } // The length of the received data is less than the length of a frame.
+        else {
             return 0;
         }
     }
-    
+
     /**
      * Websocket encode.
-     * @param string $buffer
+     *
+     * @param string              $buffer
      * @param ConnectionInterface $connection
      * @return string
      */
     public static function encode($buffer, ConnectionInterface $connection)
     {
         $len = strlen($buffer);
-        if(empty($connection->websocketType))
-        {
+        if (empty($connection->websocketType)) {
             $connection->websocketType = self::BINARY_TYPE_BLOB;
         }
-        
+
         $first_byte = $connection->websocketType;
-        
-        if($len<=125)
-        {
-            $encode_buffer = $first_byte.chr($len).$buffer;
+
+        if ($len <= 125) {
+            $encode_buffer = $first_byte . chr($len) . $buffer;
+        } else {
+            if ($len <= 65535) {
+                $encode_buffer = $first_byte . chr(126) . pack("n", $len) . $buffer;
+            } else {
+                $encode_buffer = $first_byte . chr(127) . pack("xxxxN", $len) . $buffer;
+            }
         }
-        else if($len<=65535)
-        {
-            $encode_buffer = $first_byte.chr(126).pack("n", $len).$buffer;
-        }
-        else
-        {
-            $encode_buffer = $first_byte.chr(127).pack("xxxxN", $len).$buffer;
-        }
-        
+
         // Handshake not completed so temporary buffer websocket data waiting for send.
-        if(empty($connection->websocketHandshake))
-        {
-            if(empty($connection->tmpWebsocketData))
-            {
+        if (empty($connection->websocketHandshake)) {
+            if (empty($connection->tmpWebsocketData)) {
                 $connection->tmpWebsocketData = '';
             }
             $connection->tmpWebsocketData .= $encode_buffer;
             // Return empty string.
             return '';
         }
-        
+
         return $encode_buffer;
     }
-    
+
     /**
      * Websocket decode.
-     * @param string $buffer
+     *
+     * @param string              $buffer
      * @param ConnectionInterface $connection
      * @return string
      */
@@ -274,62 +241,58 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
         $len = ord($buffer[1]) & 127;
         if ($len === 126) {
             $masks = substr($buffer, 4, 4);
-            $data = substr($buffer, 8);
-        } else if ($len === 127) {
-            $masks = substr($buffer, 10, 4);
-            $data = substr($buffer, 14);
+            $data  = substr($buffer, 8);
         } else {
-            $masks = substr($buffer, 2, 4);
-            $data = substr($buffer, 6);
+            if ($len === 127) {
+                $masks = substr($buffer, 10, 4);
+                $data  = substr($buffer, 14);
+            } else {
+                $masks = substr($buffer, 2, 4);
+                $data  = substr($buffer, 6);
+            }
         }
         for ($index = 0; $index < strlen($data); $index++) {
             $decoded .= $data[$index] ^ $masks[$index % 4];
         }
-        if($connection->websocketCurrentFrameLength)
-        {
+        if ($connection->websocketCurrentFrameLength) {
             $connection->websocketDataBuffer .= $decoded;
             return $connection->websocketDataBuffer;
-        }
-        else
-        {
-            $decoded = $connection->websocketDataBuffer . $decoded;
+        } else {
+            $decoded                         = $connection->websocketDataBuffer . $decoded;
             $connection->websocketDataBuffer = '';
             return $decoded;
         }
     }
-    
+
     /**
      * Websocket handshake.
-     * @param string $buffer
+     *
+     * @param string                              $buffer
      * @param \Workerman\Connection\TcpConnection $connection
      * @return int
      */
     protected static function dealHandshake($buffer, $connection)
     {
         // HTTP protocol.
-        if(0 === strpos($buffer, 'GET'))
-        {
+        if (0 === strpos($buffer, 'GET')) {
             // Find \r\n\r\n.
             $heder_end_pos = strpos($buffer, "\r\n\r\n");
-            if(!$heder_end_pos)
-            {
+            if (!$heder_end_pos) {
                 return 0;
             }
-            
+
             // Get Sec-WebSocket-Key.
             $Sec_WebSocket_Key = '';
-            if(preg_match("/Sec-WebSocket-Key: *(.*?)\r\n/i", $buffer, $match))
-            {
+            if (preg_match("/Sec-WebSocket-Key: *(.*?)\r\n/i", $buffer, $match)) {
                 $Sec_WebSocket_Key = $match[1];
-            }
-            else
-            {
-                $connection->send("HTTP/1.1 400 Bad Request\r\n\r\n<b>400 Bad Request</b><br>Sec-WebSocket-Key not found.<br>This is a WebSocket service and can not be accessed via HTTP.", true);
+            } else {
+                $connection->send("HTTP/1.1 400 Bad Request\r\n\r\n<b>400 Bad Request</b><br>Sec-WebSocket-Key not found.<br>This is a WebSocket service and can not be accessed via HTTP.",
+                    true);
                 $connection->close();
                 return 0;
             }
             // Calculation websocket key.
-            $new_key = base64_encode(sha1($Sec_WebSocket_Key."258EAFA5-E914-47DA-95CA-C5AB0DC85B11",true));
+            $new_key = base64_encode(sha1($Sec_WebSocket_Key . "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", true));
             // Handshake response data.
             $handshake_message = "HTTP/1.1 101 Switching Protocols\r\n";
             $handshake_message .= "Upgrade: websocket\r\n";
@@ -348,79 +311,70 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
             $connection->consumeRecvBuffer(strlen($buffer));
             // Send handshake response.
             $connection->send($handshake_message, true);
-            
+
             // There are data waiting to be sent.
-            if(!empty($connection->tmpWebsocketData))
-            {
+            if (!empty($connection->tmpWebsocketData)) {
                 $connection->send($connection->tmpWebsocketData, true);
                 $connection->tmpWebsocketData = '';
             }
             // blob or arraybuffer
-            if(empty($connection->websocketType))
-            {
+            if (empty($connection->websocketType)) {
                 $connection->websocketType = self::BINARY_TYPE_BLOB;
-            } 
+            }
             // Try to emit onWebSocketConnect callback.
-            if(isset($connection->onWebSocketConnect))
-            {
+            if (isset($connection->onWebSocketConnect)) {
                 self::parseHttpHeader($buffer);
-                try
-                {
+                try {
                     call_user_func($connection->onWebSocketConnect, $connection, $buffer);
-                }
-                catch(\Exception $e)
-                {
+                } catch (\Exception $e) {
                     echo $e;
                     exit(250);
                 }
                 $_GET = $_COOKIE = $_SERVER = array();
             }
             return 0;
-        }
-        // Is flash policy-file-request.
-        elseif(0 === strpos($buffer,'<polic'))
-        {
-            $policy_xml = '<?xml version="1.0"?><cross-domain-policy><site-control permitted-cross-domain-policies="all"/><allow-access-from domain="*" to-ports="*"/></cross-domain-policy>'."\0";
+        } // Is flash policy-file-request.
+        elseif (0 === strpos($buffer, '<polic')) {
+            $policy_xml = '<?xml version="1.0"?><cross-domain-policy><site-control permitted-cross-domain-policies="all"/><allow-access-from domain="*" to-ports="*"/></cross-domain-policy>' . "\0";
             $connection->send($policy_xml, true);
             $connection->consumeRecvBuffer(strlen($buffer));
             return 0;
         }
         // Bad websocket handshake request.
-        $connection->send("HTTP/1.1 400 Bad Request\r\n\r\n<b>400 Bad Request</b><br>Invalid handshake data for websocket. ", true);
+        $connection->send("HTTP/1.1 400 Bad Request\r\n\r\n<b>400 Bad Request</b><br>Invalid handshake data for websocket. ",
+            true);
         $connection->close();
         return 0;
     }
-    
+
     /**
      * Parse http header.
+     *
      * @param string $buffer
      * @return void
      */
     protected static function parseHttpHeader($buffer)
     {
         $header_data = explode("\r\n", $buffer);
-        $_SERVER = array();
-        list($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['SERVER_PROTOCOL']) = explode(' ', $header_data[0]);
+        $_SERVER     = array();
+        list($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['SERVER_PROTOCOL']) = explode(' ',
+            $header_data[0]);
         unset($header_data[0]);
-        foreach($header_data as $content)
-        {
+        foreach ($header_data as $content) {
             // \r\n\r\n
-            if(empty($content))
-            {
+            if (empty($content)) {
                 continue;
             }
             list($key, $value) = explode(':', $content, 2);
-            $key = strtolower($key);
+            $key   = strtolower($key);
             $value = trim($value);
-            switch($key)
-            {
+            switch ($key) {
                 // HTTP_HOST
                 case 'host':
-                    $_SERVER['HTTP_HOST'] = $value;
-                    $tmp = explode(':', $value);
+                    $_SERVER['HTTP_HOST']   = $value;
+                    $tmp                    = explode(':', $value);
                     $_SERVER['SERVER_NAME'] = $tmp[0];
-                    if(isset($tmp[1]))
-                    {
+                    if (isset($tmp[1])) {
                         $_SERVER['SERVER_PORT'] = $tmp[1];
                     }
                     break;
@@ -442,16 +396,13 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
                     break;
             }
         }
-        
+
         // QUERY_STRING
         $_SERVER['QUERY_STRING'] = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
-        if($_SERVER['QUERY_STRING'])
-        {
+        if ($_SERVER['QUERY_STRING']) {
             // $GET
             parse_str($_SERVER['QUERY_STRING'], $_GET);
-        }
-        else
-        {
+        } else {
             $_SERVER['QUERY_STRING'] = '';
         }
     }

--- a/WebServer.php
+++ b/WebServer.php
@@ -6,10 +6,10 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman;
 
@@ -23,129 +23,129 @@ class WebServer extends Worker
 {
     /**
      * Mime.
+     *
      * @var string
      */
     protected static $defaultMimeType = 'text/html; charset=utf-8';
-    
+
     /**
      * Virtual host to path mapping.
+     *
      * @var array ['workerman.net'=>'/home', 'www.workerman.net'=>'home/www']
      */
     protected $serverRoot = array();
-    
+
     /**
      * Mime mapping.
+     *
      * @var array
      */
     protected static $mimeTypeMap = array();
-    
-    
+
+
     /**
      * Used to save user OnWorkerStart callback settings.
+     *
      * @var callback
      */
     protected $_onWorkerStart = null;
-    
+
     /**
      * Add virtual host.
+     *
      * @param string $domain
      * @param string $root_path
      * @return void
      */
-    public  function addRoot($domain, $root_path)
+    public function addRoot($domain, $root_path)
     {
         $this->serverRoot[$domain] = $root_path;
     }
-    
+
     /**
      * Construct.
+     *
      * @param string $socket_name
-     * @param array $context_option
+     * @param array  $context_option
      */
     public function __construct($socket_name, $context_option = array())
     {
         list(, $address) = explode(':', $socket_name, 2);
-        parent::__construct('http:'.$address, $context_option);
+        parent::__construct('http:' . $address, $context_option);
         $this->name = 'WebServer';
     }
-    
+
     /**
      * Run webserver instance.
+     *
      * @see Workerman.Worker::run()
      */
     public function run()
     {
         $this->_onWorkerStart = $this->onWorkerStart;
-        $this->onWorkerStart = array($this, 'onWorkerStart');
-        $this->onMessage = array($this, 'onMessage');
+        $this->onWorkerStart  = array($this, 'onWorkerStart');
+        $this->onMessage      = array($this, 'onMessage');
         parent::run();
     }
-    
+
     /**
      * Emit when process start.
+     *
      * @throws \Exception
      */
     public function onWorkerStart()
     {
-        if(empty($this->serverRoot))
-        {
+        if (empty($this->serverRoot)) {
             throw new \Exception('server root not set, please use WebServer::addRoot($domain, $root_path) to set server root path');
         }
         // Init HttpCache.
         HttpCache::init();
         // Init mimeMap.
         $this->initMimeTypeMap();
-        
+
         // Try to emit onWorkerStart callback.
-        if($this->_onWorkerStart)
-        {
-            try
-            {
+        if ($this->_onWorkerStart) {
+            try {
                 call_user_func($this->_onWorkerStart, $this);
-            }
-            catch(\Exception $e)
-            {
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
         }
     }
-    
+
     /**
      * Init mime map.
+     *
      * @return void
      */
     public function initMimeTypeMap()
     {
         $mime_file = Http::getMimeTypesFile();
-        if(!is_file($mime_file))
-        {
+        if (!is_file($mime_file)) {
             $this->log("$mime_file mime.type file not fond");
             return;
         }
         $items = file($mime_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if(!is_array($items))
-        {
+        if (!is_array($items)) {
             $this->log("get $mime_file mime.type content fail");
             return;
         }
-        foreach($items as $content)
-        {
-            if(preg_match("/\s*(\S+)\s+(\S.+)/", $content, $match))
-            {
-                $mime_type = $match[1];
-                $workerman_file_extension_var = $match[2];
+        foreach ($items as $content) {
+            if (preg_match("/\s*(\S+)\s+(\S.+)/", $content, $match)) {
+                $mime_type                      = $match[1];
+                $workerman_file_extension_var   = $match[2];
                 $workerman_file_extension_array = explode(' ', substr($workerman_file_extension_var, 0, -1));
-                foreach($workerman_file_extension_array as $workerman_file_extension)
-                {
+                foreach ($workerman_file_extension_array as $workerman_file_extension) {
                     self::$mimeTypeMap[$workerman_file_extension] = $mime_type;
-                } 
+                }
             }
         }
     }
-    
+
     /**
      * Emit when http message coming.
+     *
      * @param Connection\TcpConnection $connection
      * @return void
      */
@@ -153,70 +153,61 @@ class WebServer extends Worker
     {
         // REQUEST_URI.
         $workerman_url_info = parse_url($_SERVER['REQUEST_URI']);
-        if(!$workerman_url_info)
-        {
+        if (!$workerman_url_info) {
             Http::header('HTTP/1.1 400 Bad Request');
             $connection->close('<h1>400 Bad Request</h1>');
             return;
         }
-        
+
         $workerman_path = $workerman_url_info['path'];
-        
-        $workerman_path_info = pathinfo($workerman_path);
-        $workerman_file_extension = isset($workerman_path_info['extension']) ? $workerman_path_info['extension'] : '' ;
-        if($workerman_file_extension === '')
-        {
-            $workerman_path = ($len = strlen($workerman_path)) && $workerman_path[$len -1] === '/' ? $workerman_path.'index.php' : $workerman_path . '/index.php';
+
+        $workerman_path_info      = pathinfo($workerman_path);
+        $workerman_file_extension = isset($workerman_path_info['extension']) ? $workerman_path_info['extension'] : '';
+        if ($workerman_file_extension === '') {
+            $workerman_path           = ($len = strlen($workerman_path)) && $workerman_path[$len - 1] === '/' ? $workerman_path . 'index.php' : $workerman_path . '/index.php';
             $workerman_file_extension = 'php';
         }
-        
+
         $workerman_root_dir = isset($this->serverRoot[$_SERVER['SERVER_NAME']]) ? $this->serverRoot[$_SERVER['SERVER_NAME']] : current($this->serverRoot);
-        
+
         $workerman_file = "$workerman_root_dir/$workerman_path";
-        
-        if($workerman_file_extension === 'php' && !is_file($workerman_file))
-        {
+
+        if ($workerman_file_extension === 'php' && !is_file($workerman_file)) {
             $workerman_file = "$workerman_root_dir/index.php";
-            if(!is_file($workerman_file))
-            {
-                $workerman_file = "$workerman_root_dir/index.html";
+            if (!is_file($workerman_file)) {
+                $workerman_file           = "$workerman_root_dir/index.html";
                 $workerman_file_extension = 'html';
             }
         }
-        
+
         // File exsits.
-        if(is_file($workerman_file))
-        {
+        if (is_file($workerman_file)) {
             // Security check.
-            if((!($workerman_request_realpath = realpath($workerman_file)) || !($workerman_root_dir_realpath = realpath($workerman_root_dir))) || 0 !== strpos($workerman_request_realpath, $workerman_root_dir_realpath))
-            {
+            if ((!($workerman_request_realpath = realpath($workerman_file)) || !($workerman_root_dir_realpath = realpath($workerman_root_dir))) || 0 !== strpos($workerman_request_realpath,
+                    $workerman_root_dir_realpath)
+            ) {
                 Http::header('HTTP/1.1 400 Bad Request');
                 $connection->close('<h1>400 Bad Request</h1>');
                 return;
             }
-            
+
             $workerman_file = realpath($workerman_file);
-            
+
             // Request php file.
-            if($workerman_file_extension === 'php')
-            {
+            if ($workerman_file_extension === 'php') {
                 $workerman_cwd = getcwd();
                 chdir($workerman_root_dir);
                 ini_set('display_errors', 'off');
                 ob_start();
                 // Try to include php file.
-                try 
-                {
+                try {
                     // $_SERVER.
                     $_SERVER['REMOTE_ADDR'] = $connection->getRemoteIp();
                     $_SERVER['REMOTE_PORT'] = $connection->getRemotePort();
                     include $workerman_file;
-                }
-                catch(\Exception $e) 
-                {
+                } catch (\Exception $e) {
                     // Jump_exit?
-                    if($e->getMessage() != 'jump_exit')
-                    {
+                    if ($e->getMessage() != 'jump_exit') {
                         echo $e;
                     }
                 }
@@ -226,27 +217,22 @@ class WebServer extends Worker
                 chdir($workerman_cwd);
                 return;
             }
-            
+
             // Static resource file request.
-            if(isset(self::$mimeTypeMap[$workerman_file_extension]))
-            {
-               Http::header('Content-Type: '. self::$mimeTypeMap[$workerman_file_extension]);
+            if (isset(self::$mimeTypeMap[$workerman_file_extension])) {
+                Http::header('Content-Type: ' . self::$mimeTypeMap[$workerman_file_extension]);
+            } else {
+                Http::header('Content-Type: ' . self::$defaultMimeType);
             }
-            else 
-            {
-                Http::header('Content-Type: '. self::$defaultMimeType);
-            }
-            
+
             // Get file stat.
             $info = stat($workerman_file);
-            
+
             $modified_time = $info ? date('D, d M Y H:i:s', $info['mtime']) . ' GMT' : '';
-            
-            if(!empty($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $info)
-            {
+
+            if (!empty($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $info) {
                 // Http 304.
-                if($modified_time === $_SERVER['HTTP_IF_MODIFIED_SINCE'])
-                {
+                if ($modified_time === $_SERVER['HTTP_IF_MODIFIED_SINCE']) {
                     // 304
                     Http::header('HTTP/1.1 304 Not Modified');
                     // Send nothing but http headers..
@@ -254,17 +240,14 @@ class WebServer extends Worker
                     return;
                 }
             }
-            
-            if($modified_time)
-            {
+
+            if ($modified_time) {
                 Http::header("Last-Modified: $modified_time");
             }
             // Send to client.
             $connection->close(file_get_contents($workerman_file));
             return;
-        }
-        else 
-        {
+        } else {
             // 404
             Http::header("HTTP/1.1 404 Not Found");
             $connection->close('<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>');

--- a/Worker.php
+++ b/Worker.php
@@ -6,14 +6,14 @@
  * For full copyright and license information, please see the MIT-LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @author walkor<walkor@workerman.net>
+ * @author    walkor<walkor@workerman.net>
  * @copyright walkor<walkor@workerman.net>
- * @link http://www.workerman.net/
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Workerman;
 
-require_once __DIR__.'/Lib/Constants.php';
+require_once __DIR__ . '/Lib/Constants.php';
 
 use Workerman\Events\EventInterface;
 use Workerman\Connection\ConnectionInterface;
@@ -30,315 +30,367 @@ class Worker
 {
     /**
      * Version.
+     *
      * @var string
      */
     const VERSION = '3.3.0';
-    
+
     /**
      * Status starting.
+     *
      * @var int
      */
     const STATUS_STARTING = 1;
-    
+
     /**
      * Status running.
+     *
      * @var int
      */
     const STATUS_RUNNING = 2;
-    
+
     /**
      * Status shutdown.
+     *
      * @var int
      */
     const STATUS_SHUTDOWN = 4;
-    
+
     /**
      * Status reloading.
+     *
      * @var int
      */
     const STATUS_RELOADING = 8;
-    
+
     /**
-     * After sending the restart command to the child process KILL_WORKER_TIMER_TIME seconds, 
+     * After sending the restart command to the child process KILL_WORKER_TIMER_TIME seconds,
      * if the process is still living then forced to kill.
+     *
      * @var int
      */
     const KILL_WORKER_TIMER_TIME = 2;
-    
+
     /**
      * Default backlog. Backlog is the maximum length of the queue of pending connections.
+     *
      * @var int
      */
     const DEFAUL_BACKLOG = 1024;
-    
+
     /**
      * Max udp package size.
+     *
      * @var int
      */
     const MAX_UDP_PACKAGE_SIZE = 65535;
-    
+
     /**
      * Worker id.
+     *
      * @var int
      */
     public $id = 0;
-    
+
     /**
      * Name of the worker processes.
+     *
      * @var string
      */
     public $name = 'none';
-    
+
     /**
      * Number of worker processes.
+     *
      * @var int
      */
     public $count = 1;
-    
+
     /**
      * Unix user of processes, needs appropriate privileges (usually root).
+     *
      * @var string
      */
     public $user = '';
-    
+
     /**
      * Unix group of processes, needs appropriate privileges (usually root).
+     *
      * @var string
      */
     public $group = '';
-    
+
     /**
      * reloadable.
+     *
      * @var bool
      */
     public $reloadable = true;
 
     /**
      * reuse port.
+     *
      * @var bool
      */
     public $reusePort = false;
-    
+
     /**
      * Emitted when worker processes start.
+     *
      * @var callback
      */
     public $onWorkerStart = null;
-    
+
     /**
-     * Emitted when a socket connection is successfully established. 
+     * Emitted when a socket connection is successfully established.
+     *
      * @var callback
      */
     public $onConnect = null;
-    
+
     /**
-     * Emitted when data is received. 
+     * Emitted when data is received.
+     *
      * @var callback
      */
     public $onMessage = null;
-    
+
     /**
      * Emitted when the other end of the socket sends a FIN packet.
+     *
      * @var callback
      */
     public $onClose = null;
-    
+
     /**
-     * Emitted when an error occurs with connection. 
+     * Emitted when an error occurs with connection.
+     *
      * @var callback
      */
     public $onError = null;
-    
+
     /**
-     * Emitted when the send buffer becomes full. 
+     * Emitted when the send buffer becomes full.
+     *
      * @var callback
      */
     public $onBufferFull = null;
-    
+
     /**
-     * Emitted when the send buffer becomes empty. 
+     * Emitted when the send buffer becomes empty.
+     *
      * @var callback
      */
     public $onBufferDrain = null;
-    
+
     /**
      * Emitted when worker processes stoped.
+     *
      * @var callback
      */
     public $onWorkerStop = null;
-    
+
     /**
      * Emitted when worker processes get reload command.
+     *
      * @var callback
      */
     public $onWorkerReload = null;
-    
+
     /**
      * Transport layer protocol.
+     *
      * @var string
      */
     public $transport = 'tcp';
-    
+
     /**
      * Store all connections of clients.
+     *
      * @var array
      */
     public $connections = array();
-    
+
     /**
      * Application layer protocol.
+     *
      * @var Protocols\ProtocolInterface
      */
     public $protocol = '';
-    
+
     /**
      * Root path for autoload.
+     *
      * @var string
      */
     protected $_autoloadRootPath = '';
-    
+
     /**
      * Daemonize.
+     *
      * @var bool
      */
     public static $daemonize = false;
-    
+
     /**
      * Stdout file.
+     *
      * @var string
      */
     public static $stdoutFile = '/dev/null';
-    
+
     /**
      * The file to store master process PID.
+     *
      * @var string
      */
     public static $pidFile = '';
-    
+
     /**
      * Log file.
+     *
      * @var mixed
      */
     public static $logFile = '';
-    
+
     /**
      * Global event loop.
+     *
      * @var Events\EventInterface
      */
     public static $globalEvent = null;
-    
+
     /**
      * The PID of master process.
+     *
      * @var int
      */
     protected static $_masterPid = 0;
-    
+
     /**
      * Listening socket.
+     *
      * @var resource
      */
     protected $_mainSocket = null;
-    
+
     /**
      * Socket name. The format is like this http://0.0.0.0:80 .
+     *
      * @var string
      */
     protected $_socketName = '';
-    
+
     /**
      * Context of socket.
+     *
      * @var resource
      */
     protected $_context = null;
-    
+
     /**
      * All worker instances.
+     *
      * @var array
      */
     protected static $_workers = array();
-    
+
     /**
      * All worker porcesses pid.
      * The format is like this [worker_id=>[pid=>pid, pid=>pid, ..], ..]
+     *
      * @var array
      */
     protected static $_pidMap = array();
-    
+
     /**
      * All worker processes waiting for restart.
      * The format is like this [pid=>pid, pid=>pid].
+     *
      * @var array
      */
     protected static $_pidsToRestart = array();
-    
+
     /**
      * Mapping from PID to worker process ID.
      * The format is like this [worker_id=>[0=>$pid, 1=>$pid, ..], ..].
+     *
      * @var array
      */
     protected static $_idMap = array();
-    
+
     /**
      * Current status.
+     *
      * @var int
      */
     protected static $_status = self::STATUS_STARTING;
-    
+
     /**
      * Maximum length of the worker names.
+     *
      * @var int
      */
     protected static $_maxWorkerNameLength = 12;
-    
+
     /**
      * Maximum length of the socket names.
+     *
      * @var int
      */
     protected static $_maxSocketNameLength = 12;
-    
+
     /**
      * Maximum length of the process user names.
+     *
      * @var int
      */
     protected static $_maxUserNameLength = 12;
-    
+
     /**
      * The file to store status info of current worker process.
+     *
      * @var string
      */
     protected static $_statisticsFile = '';
-    
+
     /**
      * Start file.
+     *
      * @var string
      */
     protected static $_startFile = '';
-    
+
     /**
      * Status info of current worker process.
+     *
      * @var array
      */
     protected static $_globalStatistics = array(
-        'start_timestamp' => 0,
+        'start_timestamp'  => 0,
         'worker_exit_info' => array()
     );
-    
+
     /**
      * Available event loops.
+     *
      * @var array
      */
     protected static $_availableEventLoops = array(
-        'libevent', 'ev'
+        'libevent',
+        'ev'
     );
-    
+
     /**
      * Current eventLoop name.
+     *
      * @var string
      */
     protected static $_eventLoopName = 'select';
 
     /**
      * PHP built-in protocols.
+     *
      * @var array
      */
     protected static $_builtinTransports = array(
@@ -351,9 +403,10 @@ class Worker
         'sslv3' => 'tcp',
         'tls'   => 'tcp'
     );
-    
+
     /**
      * Run all worker instances.
+     *
      * @return void
      */
     public static function runAll()
@@ -373,128 +426,118 @@ class Worker
 
     /**
      * Check sapi.
+     *
      * @return void
      */
     protected static function checkSapiEnv()
-    {   
+    {
         // Only for cli.
-        if (php_sapi_name() != "cli")
-        {
+        if (php_sapi_name() != "cli") {
             exit("only run in command line mode \n");
         }
     }
-    
+
     /**
      * Init.
+     *
      * @return void
      */
     protected static function init()
     {
         // Start file.
-        $backtrace = debug_backtrace();
-        self::$_startFile = $backtrace[count($backtrace)-1]['file'];
-        
+        $backtrace        = debug_backtrace();
+        self::$_startFile = $backtrace[count($backtrace) - 1]['file'];
+
         // Pid file.
-        if(empty(self::$pidFile))
-        {
-            self::$pidFile = __DIR__ . "/../".str_replace('/', '_', self::$_startFile).".pid";
+        if (empty(self::$pidFile)) {
+            self::$pidFile = __DIR__ . "/../" . str_replace('/', '_', self::$_startFile) . ".pid";
         }
-        
+
         // Log file.
-        if(empty(self::$logFile))
-        {
+        if (empty(self::$logFile)) {
             self::$logFile = __DIR__ . '/../workerman.log';
         }
         touch(self::$logFile);
         chmod(self::$logFile, 0622);
-        
+
         // State.
         self::$_status = self::STATUS_STARTING;
-        
+
         // For statistics.
         self::$_globalStatistics['start_timestamp'] = time();
-        self::$_statisticsFile = sys_get_temp_dir().'/workerman.status';
-        
+        self::$_statisticsFile                      = sys_get_temp_dir() . '/workerman.status';
+
         // Process title.
         self::setProcessTitle('WorkerMan: master process  start_file=' . self::$_startFile);
-        
+
         // Init data for worker id.
         self::initId();
-        
+
         // Timer init.
         Timer::init();
     }
-    
+
     /**
      * Init All worker instances.
+     *
      * @return void
      */
     protected static function initWorkers()
     {
-        foreach(self::$_workers as $worker)
-        {
+        foreach (self::$_workers as $worker) {
             // Worker name.
-            if(empty($worker->name))
-            {
+            if (empty($worker->name)) {
                 $worker->name = 'none';
             }
-            
+
             // Get maximum length of worker name.
             $worker_name_length = strlen($worker->name);
-            if(self::$_maxWorkerNameLength < $worker_name_length)
-            {
+            if (self::$_maxWorkerNameLength < $worker_name_length) {
                 self::$_maxWorkerNameLength = $worker_name_length;
             }
-            
+
             // Get maximum length of socket name.
             $socket_name_length = strlen($worker->getSocketName());
-            if(self::$_maxSocketNameLength < $socket_name_length)
-            {
+            if (self::$_maxSocketNameLength < $socket_name_length) {
                 self::$_maxSocketNameLength = $socket_name_length;
             }
-            
+
             // Get unix user of the worker process.
-            if(empty($worker->user))
-            {
+            if (empty($worker->user)) {
                 $worker->user = self::getCurrentUser();
-            }
-            else 
-            {
-                if(posix_getuid() !== 0 && $worker->user != self::getCurrentUser())
-                {
+            } else {
+                if (posix_getuid() !== 0 && $worker->user != self::getCurrentUser()) {
                     self::log('Waring: You must have the root privileges to change uid and gid.');
                 }
             }
-            
+
             // Get maximum length of unix user name.
             $user_name_length = strlen($worker->user);
-            if(self::$_maxUserNameLength < $user_name_length)
-            {
+            if (self::$_maxUserNameLength < $user_name_length) {
                 self::$_maxUserNameLength = $user_name_length;
             }
-            
+
             // Listen.
-            if(!$worker->reusePort)
-            {
+            if (!$worker->reusePort) {
                 $worker->listen();
             }
         }
     }
-    
+
     /**
      * Init idMap.
      * return void
      */
     protected static function initId()
     {
-        foreach(self::$_workers as $worker_id=>$worker)
-        {
+        foreach (self::$_workers as $worker_id => $worker) {
             self::$_idMap[$worker_id] = array_fill(0, $worker->count, 0);
         }
     }
-    
+
     /**
      * Get unix user of current porcess.
+     *
      * @return string
      */
     protected static function getCurrentUser()
@@ -502,102 +545,93 @@ class Worker
         $user_info = posix_getpwuid(posix_getuid());
         return $user_info['name'];
     }
-    
+
     /**
      * Display staring UI.
+     *
      * @return void
      */
     protected static function displayUI()
     {
         echo "\033[1A\n\033[K-----------------------\033[47;30m WORKERMAN \033[0m-----------------------------\n\033[0m";
-        echo 'Workerman version:' , Worker::VERSION , "          PHP version:",PHP_VERSION,"\n";
+        echo 'Workerman version:', Worker::VERSION, "          PHP version:", PHP_VERSION, "\n";
         echo "------------------------\033[47;30m WORKERS \033[0m-------------------------------\n";
-        echo "\033[47;30muser\033[0m",str_pad('', self::$_maxUserNameLength+2-strlen('user')), "\033[47;30mworker\033[0m",str_pad('', self::$_maxWorkerNameLength+2-strlen('worker')), "\033[47;30mlisten\033[0m",str_pad('', self::$_maxSocketNameLength+2-strlen('listen')), "\033[47;30mprocesses\033[0m \033[47;30m","status\033[0m\n";
-        
-        foreach(self::$_workers as $worker)
-        {
-            echo str_pad($worker->user, self::$_maxUserNameLength+2),str_pad($worker->name, self::$_maxWorkerNameLength+2),str_pad($worker->getSocketName(), self::$_maxSocketNameLength+2), str_pad(' '.$worker->count, 9), " \033[32;40m [OK] \033[0m\n";;
+        echo "\033[47;30muser\033[0m", str_pad('',
+            self::$_maxUserNameLength + 2 - strlen('user')), "\033[47;30mworker\033[0m", str_pad('',
+            self::$_maxWorkerNameLength + 2 - strlen('worker')), "\033[47;30mlisten\033[0m", str_pad('',
+            self::$_maxSocketNameLength + 2 - strlen('listen')), "\033[47;30mprocesses\033[0m \033[47;30m", "status\033[0m\n";
+
+        foreach (self::$_workers as $worker) {
+            echo str_pad($worker->user, self::$_maxUserNameLength + 2), str_pad($worker->name,
+                self::$_maxWorkerNameLength + 2), str_pad($worker->getSocketName(),
+                self::$_maxSocketNameLength + 2), str_pad(' ' . $worker->count, 9), " \033[32;40m [OK] \033[0m\n";;
         }
         echo "----------------------------------------------------------------\n";
-        if(self::$daemonize)
-        {
+        if (self::$daemonize) {
             global $argv;
             $start_file = $argv[0];
             echo "Input \"php $start_file stop\" to quit. Start success.\n";
-        }
-        else
-        {
+        } else {
             echo "Press Ctrl-C to quit. Start success.\n";
         }
     }
-    
+
     /**
      * Parse command.
      * php yourfile.php start | stop | restart | reload | status
+     *
      * @return void
      */
     protected static function parseCommand()
     {
         global $argv;
         // Check argv;
-        $start_file = $argv[0]; 
-        if(!isset($argv[1]))
-        {
+        $start_file = $argv[0];
+        if (!isset($argv[1])) {
             exit("Usage: php yourfile.php {start|stop|restart|reload|status|kill}\n");
         }
-        
+
         // Get command.
-        $command = trim($argv[1]);
+        $command  = trim($argv[1]);
         $command2 = isset($argv[2]) ? $argv[2] : '';
-        
+
         // Start command.
         $mode = '';
-        if($command === 'start')
-        {
-            if($command2 === '-d')
-            {
+        if ($command === 'start') {
+            if ($command2 === '-d') {
                 $mode = 'in DAEMON mode';
-            }
-            else
-            {
+            } else {
                 $mode = 'in DEBUG mode';
             }
         }
         self::log("Workerman[$start_file] $command $mode");
-        
+
         // Get master process PID.
-        $master_pid = @file_get_contents(self::$pidFile);
+        $master_pid      = @file_get_contents(self::$pidFile);
         $master_is_alive = $master_pid && @posix_kill($master_pid, 0);
         // Master is still alive?
-        if($master_is_alive)
-        {
-            if($command === 'start')
-            {
+        if ($master_is_alive) {
+            if ($command === 'start') {
                 self::log("Workerman[$start_file] already running");
                 exit;
             }
-        }
-        elseif($command !== 'start' && $command !== 'restart')
-        {
+        } elseif ($command !== 'start' && $command !== 'restart') {
             self::log("Workerman[$start_file] not run");
         }
-        
+
         // Execure command.
-        switch($command)
-        {
+        switch ($command) {
             case 'kill':
                 exec("ps aux | grep $start_file | grep -v grep | awk '{print $2}' |xargs kill -SIGINT");
                 exec("ps aux | grep $start_file | grep -v grep | awk '{print $2}' |xargs kill -SIGKILL");
                 break;
             case 'start':
-                if($command2 === '-d')
-                {
+                if ($command2 === '-d') {
                     Worker::$daemonize = true;
                 }
                 break;
             case 'status':
-                if(is_file(self::$_statisticsFile))
-                {
+                if (is_file(self::$_statisticsFile)) {
                     @unlink(self::$_statisticsFile);
                 }
                 // Master process will send status signal to all child processes.
@@ -613,17 +647,14 @@ class Worker
                 // Send stop signal to master process.
                 $master_pid && posix_kill($master_pid, SIGINT);
                 // Timeout.
-                $timeout = 5;
+                $timeout    = 5;
                 $start_time = time();
                 // Check master process is still alive?
-                while(1)
-                {
+                while (1) {
                     $master_is_alive = $master_pid && posix_kill($master_pid, 0);
-                    if($master_is_alive)
-                    {
+                    if ($master_is_alive) {
                         // Timeout?
-                        if(time() - $start_time >= $timeout)
-                        {
+                        if (time() - $start_time >= $timeout) {
                             self::log("Workerman[$start_file] stop fail");
                             exit;
                         }
@@ -633,12 +664,10 @@ class Worker
                     }
                     // Stop success.
                     self::log("Workerman[$start_file] stop success");
-                    if($command === 'stop')
-                    {
+                    if ($command === 'stop') {
                         exit(0);
                     }
-                    if($command2 === '-d')
-                    {
+                    if ($command2 === '-d') {
                         Worker::$daemonize = true;
                     }
                     break;
@@ -649,18 +678,19 @@ class Worker
                 self::log("Workerman[$start_file] reload");
                 exit;
             default :
-                 exit("Usage: php yourfile.php {start|stop|restart|reload|status|kill}\n");
+                exit("Usage: php yourfile.php {start|stop|restart|reload|status|kill}\n");
         }
     }
-    
+
     /**
      * Install signal handler.
+     *
      * @return void
      */
     protected static function installSignal()
     {
         // stop
-        pcntl_signal(SIGINT,  array('\Workerman\Worker', 'signalHandler'), false);
+        pcntl_signal(SIGINT, array('\Workerman\Worker', 'signalHandler'), false);
         // reload
         pcntl_signal(SIGUSR1, array('\Workerman\Worker', 'signalHandler'), false);
         // status
@@ -668,15 +698,16 @@ class Worker
         // ignore
         pcntl_signal(SIGPIPE, SIG_IGN, false);
     }
-    
+
     /**
      * Reinstall signal handler.
+     *
      * @return void
      */
     protected static function reinstallSignal()
     {
         // uninstall stop signal handler
-        pcntl_signal(SIGINT,  SIG_IGN, false);
+        pcntl_signal(SIGINT, SIG_IGN, false);
         // uninstall reload signal handler
         pcntl_signal(SIGUSR1, SIG_IGN, false);
         // uninstall  status signal handler
@@ -684,19 +715,19 @@ class Worker
         // reinstall stop signal handler
         self::$globalEvent->add(SIGINT, EventInterface::EV_SIGNAL, array('\Workerman\Worker', 'signalHandler'));
         //  uninstall  reload signal handler
-        self::$globalEvent->add(SIGUSR1, EventInterface::EV_SIGNAL,array('\Workerman\Worker', 'signalHandler'));
+        self::$globalEvent->add(SIGUSR1, EventInterface::EV_SIGNAL, array('\Workerman\Worker', 'signalHandler'));
         // uninstall  status signal handler
         self::$globalEvent->add(SIGUSR2, EventInterface::EV_SIGNAL, array('\Workerman\Worker', 'signalHandler'));
     }
-    
+
     /**
      * Signal hander.
+     *
      * @param int $signal
      */
     public static function signalHandler($signal)
     {
-        switch($signal)
-        {
+        switch ($signal) {
             // Stop.
             case SIGINT:
                 self::stopAll();
@@ -715,107 +746,95 @@ class Worker
 
     /**
      * Run as deamon mode.
+     *
      * @throws Exception
      */
     protected static function daemonize()
     {
-        if(!self::$daemonize)
-        {
+        if (!self::$daemonize) {
             return;
         }
         umask(0);
         $pid = pcntl_fork();
-        if(-1 === $pid)
-        {
+        if (-1 === $pid) {
             throw new Exception('fork fail');
-        }
-        elseif($pid > 0)
-        {
+        } elseif ($pid > 0) {
             exit(0);
         }
-        if(-1 === posix_setsid())
-        {
+        if (-1 === posix_setsid()) {
             throw new Exception("setsid fail");
         }
         // Fork again avoid SVR4 system regain the control of terminal.
         $pid = pcntl_fork();
-        if(-1 === $pid)
-        {
+        if (-1 === $pid) {
             throw new Exception("fork fail");
-        }
-        elseif(0 !== $pid)
-        {
+        } elseif (0 !== $pid) {
             exit(0);
         }
     }
 
     /**
      * Redirect standard input and output.
+     *
      * @throws Exception
      */
     protected static function resetStd()
     {
-        if(!self::$daemonize)
-        {
+        if (!self::$daemonize) {
             return;
         }
         global $STDOUT, $STDERR;
-        $handle = fopen(self::$stdoutFile,"a");
-        if($handle) 
-        {
+        $handle = fopen(self::$stdoutFile, "a");
+        if ($handle) {
             unset($handle);
             @fclose(STDOUT);
             @fclose(STDERR);
-            $STDOUT = fopen(self::$stdoutFile,"a");
-            $STDERR = fopen(self::$stdoutFile,"a");
-        }
-        else
-        {
+            $STDOUT = fopen(self::$stdoutFile, "a");
+            $STDERR = fopen(self::$stdoutFile, "a");
+        } else {
             throw new Exception('can not open stdoutFile ' . self::$stdoutFile);
         }
     }
-    
+
     /**
      * Save pid.
+     *
      * @throws Exception
      */
     protected static function saveMasterPid()
     {
         self::$_masterPid = posix_getpid();
-        if(false === @file_put_contents(self::$pidFile, self::$_masterPid))
-        {
+        if (false === @file_put_contents(self::$pidFile, self::$_masterPid)) {
             throw new Exception('can not save pid to ' . self::$pidFile);
         }
     }
-    
+
     /**
      * Get event loop name.
+     *
      * @return string
      */
     protected static function getEventLoopName()
     {
-        foreach(self::$_availableEventLoops as $name)
-        {
-            if(extension_loaded($name))
-            {
+        foreach (self::$_availableEventLoops as $name) {
+            if (extension_loaded($name)) {
                 self::$_eventLoopName = $name;
                 break;
             }
         }
         return self::$_eventLoopName;
     }
-    
+
     /**
      * Get all pids of worker processes.
+     *
      * @return array
      */
     protected static function getAllWorkerPids()
     {
         $pid_array = array();
-        foreach(self::$_pidMap as $worker_pid_array)
-        {
-            foreach($worker_pid_array as $worker_pid)
-            {
+        foreach (self::$_pidMap as $worker_pid_array) {
+            foreach ($worker_pid_array as $worker_pid) {
                 $pid_array[$worker_pid] = $worker_pid;
             }
         }
@@ -824,27 +843,23 @@ class Worker
 
     /**
      * Fork some worker processes.
+     *
      * @return void
      */
     protected static function forkWorkers()
     {
-        foreach(self::$_workers as $worker)
-        {
-            if(self::$_status === self::STATUS_STARTING)
-            {
-                if(empty($worker->name))
-                {
+        foreach (self::$_workers as $worker) {
+            if (self::$_status === self::STATUS_STARTING) {
+                if (empty($worker->name)) {
                     $worker->name = $worker->getSocketName();
                 }
                 $worker_name_length = strlen($worker->name);
-                if(self::$_maxWorkerNameLength < $worker_name_length)
-                {
+                if (self::$_maxWorkerNameLength < $worker_name_length) {
                     self::$_maxWorkerNameLength = $worker_name_length;
                 }
             }
-            
-            while(count(self::$_pidMap[$worker->workerId]) < $worker->count)
-            {
+
+            while (count(self::$_pidMap[$worker->workerId]) < $worker->count) {
                 static::forkOneWorker($worker);
             }
         }
@@ -852,6 +867,7 @@ class Worker
 
     /**
      * Fork one worker process.
+     *
      * @param Worker $worker
      * @throws Exception
      */
@@ -861,23 +877,18 @@ class Worker
         // Get available worker id.
         $id = self::getId($worker->workerId, 0);
         // For master process.
-        if($pid > 0)
-        {
+        if ($pid > 0) {
             self::$_pidMap[$worker->workerId][$pid] = $pid;
-            self::$_idMap[$worker->workerId][$id] = $pid;
-        }
-        // For child processes.
-        elseif(0 === $pid)
-        {
-            if($worker->reusePort)
-            {
+            self::$_idMap[$worker->workerId][$id]   = $pid;
+        } // For child processes.
+        elseif (0 === $pid) {
+            if ($worker->reusePort) {
                 $worker->listen();
             }
-            if(self::$_status === self::STATUS_STARTING)
-            {
+            if (self::$_status === self::STATUS_STARTING) {
                 self::resetStd();
             }
-            self::$_pidMap = array();
+            self::$_pidMap  = array();
             self::$_workers = array($worker->workerId => $worker);
             Timer::delAll();
             self::setProcessTitle('WorkerMan: worker process  ' . $worker->name . ' ' . $worker->getSocketName());
@@ -885,23 +896,21 @@ class Worker
             $worker->id = $id;
             $worker->run();
             exit(250);
-        }
-        else
-        {
+        } else {
             throw new Exception("forkOneWorker fail");
         }
     }
-    
+
     /**
      * Get worker id.
+     *
      * @param int $worker_id
      * @param int $pid
      */
     protected static function getId($worker_id, $pid)
     {
         $id = array_search($pid, self::$_idMap[$worker_id]);
-        if($id === false)
-        {
+        if ($id === false) {
             echo "getId fail\n";
         }
         return $id;
@@ -909,358 +918,333 @@ class Worker
 
     /**
      * Set unix user and group for current process.
+     *
      * @return void
      */
     public function setUserAndGroup()
     {
         // Get uid.
         $user_info = posix_getpwnam($this->user);
-        if(!$user_info)
-        {
-            self::log( "Waring: User {$this->user} not exsits");
+        if (!$user_info) {
+            self::log("Waring: User {$this->user} not exsits");
             return;
         }
         $uid = $user_info['uid'];
         // Get gid.
-        if($this->group)
-        {
+        if ($this->group) {
             $group_info = posix_getgrnam($this->group);
-            if(!$group_info)
-            {
-                self::log( "Waring: Group {$this->group} not exsits");
+            if (!$group_info) {
+                self::log("Waring: Group {$this->group} not exsits");
                 return;
             }
             $gid = $group_info['gid'];
-        }
-        else
-        {
+        } else {
             $gid = $user_info['gid'];
         }
-        
+
         // Set uid and gid.
-        if($uid != posix_getuid() || $gid != posix_getgid())
-        {
-            if(!posix_setgid($gid) || !posix_initgroups($user_info['name'], $gid) || !posix_setuid($uid))
-            {
-                self::log( "Waring: change gid or uid fail.");
+        if ($uid != posix_getuid() || $gid != posix_getgid()) {
+            if (!posix_setgid($gid) || !posix_initgroups($user_info['name'], $gid) || !posix_setuid($uid)) {
+                self::log("Waring: change gid or uid fail.");
             }
         }
     }
-    
+
     /**
      * Set process name.
+     *
      * @param string $title
      * @return void
      */
     protected static function setProcessTitle($title)
     {
         // >=php 5.5
-        if (function_exists('cli_set_process_title'))
-        {
+        if (function_exists('cli_set_process_title')) {
             @cli_set_process_title($title);
-        }
-        // Need proctitle when php<=5.5 .
-        elseif(extension_loaded('proctitle') && function_exists('setproctitle'))
-        {
+        } // Need proctitle when php<=5.5 .
+        elseif (extension_loaded('proctitle') && function_exists('setproctitle')) {
             @setproctitle($title);
         }
     }
-    
+
     /**
      * Monitor all child processes.
+     *
      * @return void
      */
     protected static function monitorWorkers()
     {
         self::$_status = self::STATUS_RUNNING;
-        while(1)
-        {
+        while (1) {
             // Calls signal handlers for pending signals.
             pcntl_signal_dispatch();
             // Suspends execution of the current process until a child has exited, or until a signal is delivered
             $status = 0;
-            $pid = pcntl_wait($status, WUNTRACED);
+            $pid    = pcntl_wait($status, WUNTRACED);
             // Calls signal handlers for pending signals again.
             pcntl_signal_dispatch();
             // If a child has already exited.
-            if($pid > 0)
-            {
+            if ($pid > 0) {
                 // Find out witch worker process exited.
-                foreach(self::$_pidMap as $worker_id => $worker_pid_array)
-                {
-                    if(isset($worker_pid_array[$pid]))
-                    {
+                foreach (self::$_pidMap as $worker_id => $worker_pid_array) {
+                    if (isset($worker_pid_array[$pid])) {
                         $worker = self::$_workers[$worker_id];
                         // Exit status.
-                        if($status !== 0)
-                        {
-                            self::log("worker[".$worker->name.":$pid] exit with status $status");
+                        if ($status !== 0) {
+                            self::log("worker[" . $worker->name . ":$pid] exit with status $status");
                         }
-                       
+
                         // For Statistics.
-                        if(!isset(self::$_globalStatistics['worker_exit_info'][$worker_id][$status]))
-                        {
+                        if (!isset(self::$_globalStatistics['worker_exit_info'][$worker_id][$status])) {
                             self::$_globalStatistics['worker_exit_info'][$worker_id][$status] = 0;
                         }
                         self::$_globalStatistics['worker_exit_info'][$worker_id][$status]++;
-                        
+
                         // Clear process data.
                         unset(self::$_pidMap[$worker_id][$pid]);
-                        
+
                         // Mark id is available.
-                        $id = self::getId($worker_id, $pid);
+                        $id                            = self::getId($worker_id, $pid);
                         self::$_idMap[$worker_id][$id] = 0;
-                        
+
                         break;
                     }
                 }
                 // Is still running state then fork a new worker process.
-                if(self::$_status !== self::STATUS_SHUTDOWN)
-                {
+                if (self::$_status !== self::STATUS_SHUTDOWN) {
                     self::forkWorkers();
                     // If reloading continue.
-                    if(isset(self::$_pidsToRestart[$pid]))
-                    {
+                    if (isset(self::$_pidsToRestart[$pid])) {
                         unset(self::$_pidsToRestart[$pid]);
                         self::reload();
                     }
-                }
-                else
-                {
+                } else {
                     // If shutdown state and all child processes exited then master process exit.
-                    if(!self::getAllWorkerPids())
-                    {
+                    if (!self::getAllWorkerPids()) {
                         self::exitAndClearAll();
                     }
                 }
-            }
-            else 
-            {
+            } else {
                 // If shutdown state and all child processes exited then master process exit.
-                if(self::$_status === self::STATUS_SHUTDOWN && !self::getAllWorkerPids())
-                {
-                   self::exitAndClearAll();
+                if (self::$_status === self::STATUS_SHUTDOWN && !self::getAllWorkerPids()) {
+                    self::exitAndClearAll();
                 }
             }
         }
     }
-    
+
     /**
      * Exit current process.
+     *
      * @return void
      */
     protected static function exitAndClearAll()
     {
-        foreach(self::$_workers as $worker)
-        {
+        foreach (self::$_workers as $worker) {
             $socket_name = $worker->getSocketName();
-            if($worker->transport === 'unix' && $socket_name)
-            {
+            if ($worker->transport === 'unix' && $socket_name) {
                 list(, $address) = explode(':', $socket_name, 2);
                 @unlink($address);
             }
         }
         @unlink(self::$pidFile);
-        self::log("Workerman[".basename(self::$_startFile)."] has been stopped");
+        self::log("Workerman[" . basename(self::$_startFile) . "] has been stopped");
         exit(0);
     }
-    
+
     /**
      * Execute reload.
+     *
      * @return void
      */
     protected static function reload()
     {
         // For master process.
-        if(self::$_masterPid === posix_getpid())
-        {
+        if (self::$_masterPid === posix_getpid()) {
             // Set reloading state.
-            if(self::$_status !== self::STATUS_RELOADING && self::$_status !== self::STATUS_SHUTDOWN)
-            {
-                self::log("Workerman[".basename(self::$_startFile)."] reloading");
+            if (self::$_status !== self::STATUS_RELOADING && self::$_status !== self::STATUS_SHUTDOWN) {
+                self::log("Workerman[" . basename(self::$_startFile) . "] reloading");
                 self::$_status = self::STATUS_RELOADING;
             }
-            
+
             // Send reload signal to all child processes.
             $reloadable_pid_array = array();
-            foreach(self::$_pidMap as $worker_id =>$worker_pid_array)
-            {
+            foreach (self::$_pidMap as $worker_id => $worker_pid_array) {
                 $worker = self::$_workers[$worker_id];
-                if($worker->reloadable)
-                {
-                    foreach($worker_pid_array as $pid)
-                    {
+                if ($worker->reloadable) {
+                    foreach ($worker_pid_array as $pid) {
                         $reloadable_pid_array[$pid] = $pid;
                     }
-                }
-                else
-                {
-                    foreach($worker_pid_array as $pid)
-                    {
+                } else {
+                    foreach ($worker_pid_array as $pid) {
                         // Send reload signal to a worker process which reloadable is false.
                         posix_kill($pid, SIGUSR1);
                     }
                 }
             }
-            
+
             // Get all pids that are waiting reload.
-            self::$_pidsToRestart = array_intersect(self::$_pidsToRestart , $reloadable_pid_array);
-            
+            self::$_pidsToRestart = array_intersect(self::$_pidsToRestart, $reloadable_pid_array);
+
             // Reload complete.
-            if(empty(self::$_pidsToRestart))
-            {
-                if(self::$_status !== self::STATUS_SHUTDOWN)
-                {
+            if (empty(self::$_pidsToRestart)) {
+                if (self::$_status !== self::STATUS_SHUTDOWN) {
                     self::$_status = self::STATUS_RUNNING;
                 }
                 return;
             }
             // Continue reload.
-            $one_worker_pid = current(self::$_pidsToRestart );
+            $one_worker_pid = current(self::$_pidsToRestart);
             // Send reload signal to a worker process.
             posix_kill($one_worker_pid, SIGUSR1);
             // If the process does not exit after self::KILL_WORKER_TIMER_TIME seconds try to kill it.
             Timer::add(self::KILL_WORKER_TIMER_TIME, 'posix_kill', array($one_worker_pid, SIGKILL), false);
-        }
-        // For child processes.
-        else
-        {
+        } // For child processes.
+        else {
             $worker = current(self::$_workers);
             // Try to emit onWorkerReload callback.
-            if($worker->onWorkerReload)
-            {
-                try 
-                {
+            if ($worker->onWorkerReload) {
+                try {
                     call_user_func($worker->onWorkerReload, $worker);
-                }
-                catch(\Exception $e)
-                {
+                } catch (\Exception $e) {
                     echo $e;
                     exit(250);
                 }
             }
-            
-            if($worker->reloadable)
-            {
+
+            if ($worker->reloadable) {
                 self::stopAll();
             }
         }
-    } 
-    
+    }
+
     /**
      * Stop.
+     *
      * @return void
      */
     public static function stopAll()
     {
         self::$_status = self::STATUS_SHUTDOWN;
         // For master process.
-        if(self::$_masterPid === posix_getpid())
-        {
-            self::log("Workerman[".basename(self::$_startFile)."] Stopping ...");
+        if (self::$_masterPid === posix_getpid()) {
+            self::log("Workerman[" . basename(self::$_startFile) . "] Stopping ...");
             $worker_pid_array = self::getAllWorkerPids();
             // Send stop signal to all child processes.
-            foreach($worker_pid_array as $worker_pid)
-            {
+            foreach ($worker_pid_array as $worker_pid) {
                 posix_kill($worker_pid, SIGINT);
-                Timer::add(self::KILL_WORKER_TIMER_TIME, 'posix_kill', array($worker_pid, SIGKILL),false);
+                Timer::add(self::KILL_WORKER_TIMER_TIME, 'posix_kill', array($worker_pid, SIGKILL), false);
             }
-        }
-        // For child processes.
-        else
-        {
+        } // For child processes.
+        else {
             // Execute exit.
-            foreach(self::$_workers as $worker)
-            {
+            foreach (self::$_workers as $worker) {
                 $worker->stop();
             }
             exit(0);
         }
     }
-    
+
     /**
      * Write statistics data to disk.
+     *
      * @return void
      */
     protected static function writeStatisticsToStatusFile()
     {
         // For master process.
-        if(self::$_masterPid === posix_getpid())
-        {
+        if (self::$_masterPid === posix_getpid()) {
             $loadavg = sys_getloadavg();
-            file_put_contents(self::$_statisticsFile, "---------------------------------------GLOBAL STATUS--------------------------------------------\n");
-            file_put_contents(self::$_statisticsFile, 'Workerman version:' . Worker::VERSION . "          PHP version:".PHP_VERSION."\n", FILE_APPEND);
-            file_put_contents(self::$_statisticsFile, 'start time:'. date('Y-m-d H:i:s', self::$_globalStatistics['start_timestamp']).'   run ' . floor((time()-self::$_globalStatistics['start_timestamp'])/(24*60*60)). ' days ' . floor(((time()-self::$_globalStatistics['start_timestamp'])%(24*60*60))/(60*60)) . " hours   \n", FILE_APPEND);
+            file_put_contents(self::$_statisticsFile,
+                "---------------------------------------GLOBAL STATUS--------------------------------------------\n");
+            file_put_contents(self::$_statisticsFile,
+                'Workerman version:' . Worker::VERSION . "          PHP version:" . PHP_VERSION . "\n", FILE_APPEND);
+            file_put_contents(self::$_statisticsFile, 'start time:' . date('Y-m-d H:i:s',
+                    self::$_globalStatistics['start_timestamp']) . '   run ' . floor((time() - self::$_globalStatistics['start_timestamp']) / (24 * 60 * 60)) . ' days ' . floor(((time() - self::$_globalStatistics['start_timestamp']) % (24 * 60 * 60)) / (60 * 60)) . " hours   \n",
+                FILE_APPEND);
             $load_str = 'load average: ' . implode(", ", $loadavg);
-            file_put_contents(self::$_statisticsFile, str_pad($load_str, 33) . 'event-loop:'.self::getEventLoopName()."\n", FILE_APPEND);
-            file_put_contents(self::$_statisticsFile,  count(self::$_pidMap) . ' workers       ' . count(self::getAllWorkerPids())." processes\n", FILE_APPEND);
-            file_put_contents(self::$_statisticsFile, str_pad('worker_name', self::$_maxWorkerNameLength) . " exit_status     exit_count\n", FILE_APPEND);
-            foreach(self::$_pidMap as $worker_id =>$worker_pid_array)
-            {
+            file_put_contents(self::$_statisticsFile,
+                str_pad($load_str, 33) . 'event-loop:' . self::getEventLoopName() . "\n", FILE_APPEND);
+            file_put_contents(self::$_statisticsFile,
+                count(self::$_pidMap) . ' workers       ' . count(self::getAllWorkerPids()) . " processes\n",
+                FILE_APPEND);
+            file_put_contents(self::$_statisticsFile,
+                str_pad('worker_name', self::$_maxWorkerNameLength) . " exit_status     exit_count\n", FILE_APPEND);
+            foreach (self::$_pidMap as $worker_id => $worker_pid_array) {
                 $worker = self::$_workers[$worker_id];
-                if(isset(self::$_globalStatistics['worker_exit_info'][$worker_id]))
-                {
-                    foreach(self::$_globalStatistics['worker_exit_info'][$worker_id] as $worker_exit_status=>$worker_exit_count)
-                    {
-                        file_put_contents(self::$_statisticsFile, str_pad($worker->name, self::$_maxWorkerNameLength) . " " . str_pad($worker_exit_status, 16). " $worker_exit_count\n", FILE_APPEND);
+                if (isset(self::$_globalStatistics['worker_exit_info'][$worker_id])) {
+                    foreach (self::$_globalStatistics['worker_exit_info'][$worker_id] as $worker_exit_status => $worker_exit_count) {
+                        file_put_contents(self::$_statisticsFile,
+                            str_pad($worker->name, self::$_maxWorkerNameLength) . " " . str_pad($worker_exit_status,
+                                16) . " $worker_exit_count\n", FILE_APPEND);
                     }
-                }
-                else
-                {
-                    file_put_contents(self::$_statisticsFile, str_pad($worker->name, self::$_maxWorkerNameLength) . " " . str_pad(0, 16). " 0\n", FILE_APPEND);
+                } else {
+                    file_put_contents(self::$_statisticsFile,
+                        str_pad($worker->name, self::$_maxWorkerNameLength) . " " . str_pad(0, 16) . " 0\n",
+                        FILE_APPEND);
                 }
             }
-            file_put_contents(self::$_statisticsFile,  "---------------------------------------PROCESS STATUS-------------------------------------------\n", FILE_APPEND);
-            file_put_contents(self::$_statisticsFile, "pid\tmemory  ".str_pad('listening', self::$_maxSocketNameLength)." ".str_pad('worker_name', self::$_maxWorkerNameLength)." connections ".str_pad('total_request', 13)." ".str_pad('send_fail', 9)." ".str_pad('throw_exception', 15)."\n", FILE_APPEND);
-            
+            file_put_contents(self::$_statisticsFile,
+                "---------------------------------------PROCESS STATUS-------------------------------------------\n",
+                FILE_APPEND);
+            file_put_contents(self::$_statisticsFile,
+                "pid\tmemory  " . str_pad('listening', self::$_maxSocketNameLength) . " " . str_pad('worker_name',
+                    self::$_maxWorkerNameLength) . " connections " . str_pad('total_request',
+                    13) . " " . str_pad('send_fail', 9) . " " . str_pad('throw_exception', 15) . "\n", FILE_APPEND);
+
             chmod(self::$_statisticsFile, 0722);
-            
-            foreach(self::getAllWorkerPids() as $worker_pid)
-            {
+
+            foreach (self::getAllWorkerPids() as $worker_pid) {
                 posix_kill($worker_pid, SIGUSR2);
             }
             return;
         }
-        
+
         // For child processes.
         /** @var Worker $worker */
-        $worker = current(self::$_workers);
-        $wrker_status_str = posix_getpid()."\t".str_pad(round(memory_get_usage(true)/(1024*1024),2)."M", 7)." " .str_pad($worker->getSocketName(), self::$_maxSocketNameLength) ." ".str_pad(($worker->name === $worker->getSocketName() ? 'none' : $worker->name), self::$_maxWorkerNameLength)." ";
-        $wrker_status_str .= str_pad(ConnectionInterface::$statistics['connection_count'], 11)." ".str_pad(ConnectionInterface::$statistics['total_request'], 14)." ".str_pad(ConnectionInterface::$statistics['send_fail'],9)." ".str_pad(ConnectionInterface::$statistics['throw_exception'],15)."\n";
+        $worker           = current(self::$_workers);
+        $wrker_status_str = posix_getpid() . "\t" . str_pad(round(memory_get_usage(true) / (1024 * 1024), 2) . "M",
+                7) . " " . str_pad($worker->getSocketName(),
+                self::$_maxSocketNameLength) . " " . str_pad(($worker->name === $worker->getSocketName() ? 'none' : $worker->name),
+                self::$_maxWorkerNameLength) . " ";
+        $wrker_status_str .= str_pad(ConnectionInterface::$statistics['connection_count'],
+                11) . " " . str_pad(ConnectionInterface::$statistics['total_request'],
+                14) . " " . str_pad(ConnectionInterface::$statistics['send_fail'],
+                9) . " " . str_pad(ConnectionInterface::$statistics['throw_exception'], 15) . "\n";
         file_put_contents(self::$_statisticsFile, $wrker_status_str, FILE_APPEND);
     }
-    
+
     /**
      * Check errors when current process exited.
+     *
      * @return void
      */
     public static function checkErrors()
     {
-        if(self::STATUS_SHUTDOWN != self::$_status)
-        {
+        if (self::STATUS_SHUTDOWN != self::$_status) {
             $error_msg = "WORKER EXIT UNEXPECTED ";
-            $errors = error_get_last();
-            if($errors && ($errors['type'] === E_ERROR ||
-                     $errors['type'] === E_PARSE ||
-                     $errors['type'] === E_CORE_ERROR ||
-                     $errors['type'] === E_COMPILE_ERROR || 
-                     $errors['type'] === E_RECOVERABLE_ERROR ))
-            {
+            $errors    = error_get_last();
+            if ($errors && ($errors['type'] === E_ERROR ||
+                    $errors['type'] === E_PARSE ||
+                    $errors['type'] === E_CORE_ERROR ||
+                    $errors['type'] === E_COMPILE_ERROR ||
+                    $errors['type'] === E_RECOVERABLE_ERROR)
+            ) {
                 $error_msg .= self::getErrorType($errors['type']) . " {$errors['message']} in {$errors['file']} on line {$errors['line']}";
             }
             self::log($error_msg);
         }
     }
-    
+
     /**
      * Get error message by error code.
+     *
      * @param integer $type
      * @return string
      */
     protected static function getErrorType($type)
     {
-        switch($type)
-        {
+        switch ($type) {
             case E_ERROR: // 1 //
                 return 'E_ERROR';
             case E_WARNING: // 2 //
@@ -1294,17 +1278,17 @@ class Worker
         }
         return "";
     }
-    
+
     /**
      * Log.
+     *
      * @param string $msg
      * @return void
      */
     protected static function log($msg)
     {
-        $msg = $msg."\n";
-        if(!self::$daemonize)
-        {
+        $msg = $msg . "\n";
+        if (!self::$daemonize) {
             echo $msg;
         }
         file_put_contents(self::$logFile, date('Y-m-d H:i:s') . " " . $msg, FILE_APPEND | LOCK_EX);
@@ -1319,40 +1303,39 @@ class Worker
     public function __construct($socket_name = '', $context_option = array())
     {
         // Save all worker instances.
-        $this->workerId = spl_object_hash($this);
+        $this->workerId                  = spl_object_hash($this);
         self::$_workers[$this->workerId] = $this;
-        self::$_pidMap[$this->workerId] = array();
-        
+        self::$_pidMap[$this->workerId]  = array();
+
         // Get autoload root path.
-        $backrace = debug_backtrace();
+        $backrace                = debug_backtrace();
         $this->_autoloadRootPath = dirname($backrace[0]['file']);
-        
+
         // Context for socket.
-        if($socket_name)
-        {
+        if ($socket_name) {
             $this->_socketName = $socket_name;
-            if(!isset($context_option['socket']['backlog']))
-            {
+            if (!isset($context_option['socket']['backlog'])) {
                 $context_option['socket']['backlog'] = self::DEFAUL_BACKLOG;
             }
             $this->_context = stream_context_create($context_option);
         }
-        
+
         // Set an empty onMessage callback.
-        $this->onMessage = function(){};
+        $this->onMessage = function () {
+        };
     }
-    
+
     /**
      * Listen port.
+     *
      * @throws Exception
      */
     public function listen()
     {
-        if(!$this->_socketName || $this->_mainSocket)
-        {
+        if (!$this->_socketName || $this->_mainSocket) {
             return;
         }
- 
+
         // Autoload.
         Autoloader::setRootPath($this->_autoloadRootPath);
 
@@ -1360,157 +1343,138 @@ class Worker
         // Get the application layer communication protocol and listening address.
         list($scheme, $address) = explode(':', $this->_socketName, 2);
         // Check application layer protocol class.
-        if(!isset(self::$_builtinTransports[$scheme]))
-        {
-            $scheme = ucfirst($scheme);
-            $this->protocol = '\\Protocols\\'.$scheme;
-            if(!class_exists($this->protocol))
-            {
+        if (!isset(self::$_builtinTransports[$scheme])) {
+            $scheme         = ucfirst($scheme);
+            $this->protocol = '\\Protocols\\' . $scheme;
+            if (!class_exists($this->protocol)) {
                 $this->protocol = "\\Workerman\\Protocols\\$scheme";
-                if(!class_exists($this->protocol))
-                {
+                if (!class_exists($this->protocol)) {
                     throw new Exception("class \\Protocols\\$scheme not exist");
                 }
             }
-            $local_socket = $this->transport.":".$address;
-        }
-        else
-        {
+            $local_socket = $this->transport . ":" . $address;
+        } else {
             $this->transport = self::$_builtinTransports[$scheme];
         }
-        
+
         // Flag.
-        $flags =  $this->transport === 'udp' ? STREAM_SERVER_BIND : STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
-        $errno = 0;
+        $flags  = $this->transport === 'udp' ? STREAM_SERVER_BIND : STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
+        $errno  = 0;
         $errmsg = '';
         // SO_REUSEPORT.
-        if($this->reusePort)
-        {
+        if ($this->reusePort) {
             stream_context_set_option($this->_context, 'socket', 'so_reuseport', 1);
         }
-        if($this->transport === 'unix')
-        {
+        if ($this->transport === 'unix') {
             umask(0);
             list(, $address) = explode(':', $this->_socketName, 2);
-            if(!is_file($address))
-            {
-                register_shutdown_function(function()use($address){@unlink($address);});
+            if (!is_file($address)) {
+                register_shutdown_function(function () use ($address) {
+                    @unlink($address);
+                });
             }
         }
         // Create an Internet or Unix domain server socket.
         $this->_mainSocket = stream_socket_server($local_socket, $errno, $errmsg, $flags, $this->_context);
-        if(!$this->_mainSocket)
-        {
+        if (!$this->_mainSocket) {
             throw new Exception($errmsg);
         }
-        
+
         // Try to open keepalive for tcp and disable Nagle algorithm.
-        if(function_exists('socket_import_stream') && $this->transport === 'tcp')
-        {
-            $socket   = socket_import_stream($this->_mainSocket );
+        if (function_exists('socket_import_stream') && $this->transport === 'tcp') {
+            $socket = socket_import_stream($this->_mainSocket);
             @socket_set_option($socket, SOL_SOCKET, SO_KEEPALIVE, 1);
             @socket_set_option($socket, SOL_TCP, TCP_NODELAY, 1);
         }
-        
+
         // Non blocking.
         stream_set_blocking($this->_mainSocket, 0);
-        
+
         // Register a listener to be notified when server socket is ready to read.
-        if(self::$globalEvent)
-        {
-            if($this->transport !== 'udp')
-            {
+        if (self::$globalEvent) {
+            if ($this->transport !== 'udp') {
                 self::$globalEvent->add($this->_mainSocket, EventInterface::EV_READ, array($this, 'acceptConnection'));
-            }
-            else
-            {
-                self::$globalEvent->add($this->_mainSocket,  EventInterface::EV_READ, array($this, 'acceptUdpConnection'));
+            } else {
+                self::$globalEvent->add($this->_mainSocket, EventInterface::EV_READ,
+                    array($this, 'acceptUdpConnection'));
             }
         }
     }
-    
+
     /**
      * Get socket name.
+     *
      * @return string
      */
     public function getSocketName()
     {
         return $this->_socketName ? lcfirst($this->_socketName) : 'none';
     }
-    
+
     /**
      * Run worker instance.
+     *
      * @return void
      */
     public function run()
     {
         //Update process state.
         self::$_status = self::STATUS_RUNNING;
-        
+
         // Eegister shutdown function for checking errors.
         register_shutdown_function(array("\\Workerman\\Worker", 'checkErrors'));
-        
+
         // Set autoload root path.
         Autoloader::setRootPath($this->_autoloadRootPath);
-        
+
         // Create a global event loop.
-        if(!self::$globalEvent)
-        {
-            $eventLoopClass = "\\Workerman\\Events\\". ucfirst(self::getEventLoopName());
+        if (!self::$globalEvent) {
+            $eventLoopClass    = "\\Workerman\\Events\\" . ucfirst(self::getEventLoopName());
             self::$globalEvent = new $eventLoopClass;
             // Register a listener to be notified when server socket is ready to read.
-            if($this->_socketName)
-            {
-                if($this->transport !== 'udp')
-                {
-                    self::$globalEvent->add($this->_mainSocket, EventInterface::EV_READ, array($this, 'acceptConnection'));
-                }
-                else
-                {
-                    self::$globalEvent->add($this->_mainSocket,  EventInterface::EV_READ, array($this, 'acceptUdpConnection'));
+            if ($this->_socketName) {
+                if ($this->transport !== 'udp') {
+                    self::$globalEvent->add($this->_mainSocket, EventInterface::EV_READ,
+                        array($this, 'acceptConnection'));
+                } else {
+                    self::$globalEvent->add($this->_mainSocket, EventInterface::EV_READ,
+                        array($this, 'acceptUdpConnection'));
                 }
             }
         }
-        
+
         // Reinstall signal.
         self::reinstallSignal();
-        
+
         // Init Timer.
         Timer::init(self::$globalEvent);
-        
+
         // Try to emit onWorkerStart callback.
-        if($this->onWorkerStart)
-        {
-            try 
-            {
+        if ($this->onWorkerStart) {
+            try {
                 call_user_func($this->onWorkerStart, $this);
-            }
-            catch(\Exception $e)
-            {
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
         }
-        
+
         // Main loop.
         self::$globalEvent->loop();
     }
-    
+
     /**
      * Stop current worker instance.
+     *
      * @return void
      */
     public function stop()
     {
         // Try to emit onWorkerStop callback.
-        if($this->onWorkerStop)
-        {
-            try 
-            {
+        if ($this->onWorkerStop) {
+            try {
                 call_user_func($this->onWorkerStop, $this);
-            }
-            catch(\Exception $e)
-            {
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
@@ -1522,6 +1486,7 @@ class Worker
 
     /**
      * Accept a connection.
+     *
      * @param resource $socket
      * @return void
      */
@@ -1530,31 +1495,26 @@ class Worker
         // Accept a connection on server socket.
         $new_socket = @stream_socket_accept($socket, 0, $remote_address);
         // Thundering herd.
-        if(false === $new_socket)
-        {
+        if (false === $new_socket) {
             return;
         }
-        
+
         // TcpConnection.
-        $connection = new TcpConnection($new_socket, $remote_address);
+        $connection                         = new TcpConnection($new_socket, $remote_address);
         $this->connections[$connection->id] = $connection;
-        $connection->worker = $this;
-        $connection->protocol = $this->protocol;
-        $connection->onMessage = $this->onMessage;
-        $connection->onClose = $this->onClose;
-        $connection->onError = $this->onError;
-        $connection->onBufferDrain = $this->onBufferDrain;
-        $connection->onBufferFull = $this->onBufferFull;
-        
+        $connection->worker                 = $this;
+        $connection->protocol               = $this->protocol;
+        $connection->onMessage              = $this->onMessage;
+        $connection->onClose                = $this->onClose;
+        $connection->onError                = $this->onError;
+        $connection->onBufferDrain          = $this->onBufferDrain;
+        $connection->onBufferFull           = $this->onBufferFull;
+
         // Try to emit onConnect callback.
-        if($this->onConnect)
-        {
-            try
-            {
+        if ($this->onConnect) {
+            try {
                 call_user_func($this->onConnect, $connection);
-            }
-            catch(\Exception $e)
-            {
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }
@@ -1569,28 +1529,22 @@ class Worker
      */
     public function acceptUdpConnection($socket)
     {
-        $recv_buffer = stream_socket_recvfrom($socket , self::MAX_UDP_PACKAGE_SIZE, 0, $remote_address);
-        if(false === $recv_buffer || empty($remote_address))
-        {
+        $recv_buffer = stream_socket_recvfrom($socket, self::MAX_UDP_PACKAGE_SIZE, 0, $remote_address);
+        if (false === $recv_buffer || empty($remote_address)) {
             return false;
         }
         // UdpConnection.
-        $connection = new UdpConnection($socket, $remote_address);
+        $connection           = new UdpConnection($socket, $remote_address);
         $connection->protocol = $this->protocol;
-        if($this->onMessage)
-        {
-            if($this->protocol)
-            {
-                $parser = $this->protocol;
+        if ($this->onMessage) {
+            if ($this->protocol) {
+                $parser      = $this->protocol;
                 $recv_buffer = $parser::decode($recv_buffer, $connection);
             }
             ConnectionInterface::$statistics['total_request']++;
-            try
-            {
+            try {
                 call_user_func($this->onMessage, $connection, $recv_buffer);
-            }
-            catch(\Exception $e)
-            {
+            } catch (\Exception $e) {
                 echo $e;
                 exit(250);
             }


### PR DESCRIPTION
更改编码风格为 [PSR-2](http://www.php-fig.org/psr/psr-2/)（[PSR-2中文翻译](https://segmentfault.com/a/1190000002521620) )风格。

改用 PSR-2 编码规范的理由如下：
* 主流的PHP框架：[Symfony](http://symfony.com/doc/current/contributing/code/standards.html)，[Laravel](https://laravel.com/docs/5.1/contributions#coding-style)，[Yii2](https://github.com/yiisoft/yii2/blob/master/docs/internals/core-code-style.md#1-overview)，
[CakePHP](http://book.cakephp.org/3.0/en/contributing/cakephp-coding-conventions.html#coding-standards)，[Nette](https://nette.org/en/coding-standard)，[SlimPHP](http://www.slimframework.com/2012/09/13/version-2.html#whats-new), [PhalconPHP](https://forum.phalconphp.com/discussion/1049/coding-standards#C3938)等等均采用 PSR-2规范。
* 采用大家都比较同意的编码风格（PSR-2是各个框架的代表投票出来的编码风格），有助于 Workerman 与其他框架的互操作性。

