### PR TITLE
fix udp

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -1553,6 +1553,9 @@ class Worker
             if ($this->protocol) {
                 $parser      = $this->protocol;
                 $recv_buffer = $parser::decode($recv_buffer, $connection);
+                // Discard bad packets.
+                if ($recv_buffer === false)
+                    return true;
             }
             ConnectionInterface::$statistics['total_request']++;
             try {


### PR DESCRIPTION
用户自定义的udp协议中，若收到的数据包格式不对或者损坏，decode方法可返回false，则worker不会调用onMessage回调。