### PR TITLE
Check if $fd is null before call cancelTimer

### DIFF
--- a/Events/React.php
+++ b/Events/React.php
@@ -87,7 +87,9 @@ class React implements LoopInterface
                 return $this->_loop->removeSignal($fd);
             case EventInterface::EV_TIMER:
             case EventInterface::EV_TIMER_ONCE;
-                return  $this->_loop->cancelTimer($fd);
+                if ($fd !== null){
+                    return  $this->_loop->cancelTimer($fd);
+                }
         }
         return false;
     }


### PR DESCRIPTION
Fix error: "Argument 1 passed to React\EventLoop\StreamSelectLoop::cancelTimer() must implement interface React\EventLoop\Timer\TimerInterface, null given, called in workerman/Events/React.php on line 90"