### PR TITLE
Fix: unix AsyncTcpConnection error

### DIFF
--- a/Connection/AsyncTcpConnection.php
+++ b/Connection/AsyncTcpConnection.php
@@ -106,8 +106,10 @@ class AsyncTcpConnection extends TcpConnection
     {
         $address_info = parse_url($remote_address);
         if (!$address_info) {
-            echo new \Exception('bad remote_address');
-            $this->_remoteAddress = $remote_address;
+            list($scheme, $this->_remoteAddress) = explode(':', $remote_address, 2);
+            if (!$this->_remoteAddress) {
+                echo new \Exception('bad remote_address');
+            }
         } else {
             if (!isset($address_info['port'])) {
                 $address_info['port'] = 80;


### PR DESCRIPTION
Fix unix connection error.
Example of bad remote address: 'unix:///tmp/auth.sock'
#142 