### PR TITLE
Allow log rotation by making the redirection public

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -811,7 +811,7 @@ class Worker
      *
      * @throws Exception
      */
-    protected static function resetStd()
+    public static function resetStd()
     {
         if (!self::$daemonize) {
             return;


### PR DESCRIPTION
Hi @walkor 

I am running Workerman on a very long run and I did a process that runs at midnight everyday and rotate the logs, it needs to call `resetStd` to work. Please accept this small change for this to work.
I put an example below on how this works.

Thanks

```php
/**
 * Rotate the logs of this particular worker
 * @param $worker
 */
function rotate_log($worker)
{
	//If it is midnight
	if(date("H:i:s") == "00:00:01")
	{
		$worker::$stdoutFile = LOG_DIRECTORY . LOG_FILE_NAME_PREFIX . date("Ymd") . LOG_FILE_NAME_SUFFIX;
		$worker::$logFile = LOG_DIRECTORY . "workerman_" . date("Ymd") . LOG_FILE_NAME_SUFFIX;
		$worker::resetStd();
	}
}
```