### PR TITLE
Default React for SELECT

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -878,7 +878,7 @@ class Worker
                 self::$eventLoopClass = self::$_availableEventLoops[$loop_name];
             }
         } else {
-            self::$eventLoopClass = '\Workerman\Events\Select';
+            self::$eventLoopClass = interface_exists('\React\EventLoop\LoopInterface')? '\Workerman\Events\React\StreamSelectLoop':'\Workerman\Events\Select';
         }
         return self::$eventLoopClass;
     }


### PR DESCRIPTION
Hello

Today I decide to update workerman , I have new issue and I let to open a pull request

In https://github.com/walkor/Workerman/commit/16bcc9edbf14dbcf4d95bb4d180c5e740470f6f7 as there is no select in $_availableEventLoops , https://github.com/walkor/Workerman/blob/master/Worker.php#L864 is always false so default class is '\Workerman\Events\Select' not '\Workerman\Events\React\StreamSelectLoop' even '\React\EventLoop\LoopInterface' is exists