### PR TITLE
session_save_path warning

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -561,7 +561,7 @@ class HttpCache
     public static function init()
     {
         self::$sessionName = ini_get('session.name');
-        self::$sessionPath = session_save_path();
+        self::$sessionPath = @session_save_path();
         if (!self::$sessionPath || strpos(self::$sessionPath, 'tcp://') === 0) {
             self::$sessionPath = sys_get_temp_dir();
         }


### PR DESCRIPTION
非守护进程模式启动已http协议运行的时候 parseCommand中第一个log echo 会引起 Warning: session_save_path(): Cannot change save path when headers already sent，这样往其他框架中集成Workerman的时候调试不是很方便