### PR TITLE
fix Timer 

### DIFF
--- a/Events/Select.php
+++ b/Events/Select.php
@@ -142,7 +142,12 @@ class Select implements EventInterface
                 $run_time = microtime(true) + $fd;
                 $this->_scheduler->insert($this->_timerId, -$run_time);
                 $this->_eventTimer[$this->_timerId] = array($func, (array)$args, $flag, $fd);
-                $this->tick();
+                
+                $scheduler_data       = $this->_scheduler->top();
+                $next_run_time        = -$scheduler_data['priority']; 
+                $timeout = ($next_run_time - $run_time) * 1000000;
+                if( $timeout >= 0 ) $this->_selectTimeout =  $timeout +1;
+                
                 return $this->_timerId++;
         }
 


### PR DESCRIPTION
问题代码：
```php 
$w = new \Workerman\Worker();
$w->onWorkerStart=function(){

    $co1 = function()use(&$co1){ 
        \Workerman\Lib\Timer::add(2.1, function()use(&$co1) {
            echo "co1\n";
            $co1();
        },[],false); 
    };

    $co2 = function()use(&$co2) { 
        \Workerman\Lib\Timer::add(2.1, function()use(&$co2) {
            echo "co2\n";
            $co2();
        },[],false); 
    }; 

    $co1();
    $co2(); 
}; 
\Workerman\Worker::runAll();
```
输出：
``` php  
----------------------- WORKERMAN -----------------------------
Workerman version:3.3.90          PHP version:7.0.13
------------------------ WORKERS -------------------------------
worker        listen        processes status
none          none           1        [OK] 
----------------------------------------------------------------
Press Ctrl-C to quit. Start success.
co1
co2
co2
co2
co2
co2
co2
co2
...
```