### PR TITLE
Websocket - outgoing PING packets, now this packet contains MASK.

### DIFF
--- a/Protocols/Ws.php
+++ b/Protocols/Ws.php
@@ -412,7 +412,7 @@ class Ws
             // Headbeat.
             if (!empty($connection->websocketPingInterval)) {
                 $connection->websocketPingTimer = Timer::add($connection->websocketPingInterval, function() use ($connection){
-                    if (false === $connection->send(pack('H*', '8900'), true)) {
+                    if (false === $connection->send(pack('H*', '898000000000'), true)) {
                         Timer::del($connection->websocketPingTimer);
                         $connection->websocketPingTimer = null;
                     }


### PR DESCRIPTION
According to Section 5.2 of the specification, all frames from client to server have the mask bit set to 1.
I faced an issue, that a WS server drops connection when sending PING request without MASK. Adding mask fixed this problem.