### PR TITLE
Adding support of custom functions within protocols

### DIFF
--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -254,6 +254,31 @@ class TcpConnection extends ConnectionInterface
         self::STATUS_CLOSED      => 'CLOSED',
     );
 
+
+    /**
+     * Adding support of custom functions within protocols
+     *
+     * @param string $name
+     * @param array  $arguments
+     */
+    public function __call($name, $arguments) {
+        // Try to emit custom function within protocol
+        if (method_exists($this->protocol, $name)) {
+            try {
+                return call_user_func(array($this->protocol, $name), $this, $arguments);
+            } catch (\Exception $e) {
+                Worker::log($e);
+                exit(250);
+            } catch (\Error $e) {
+                Worker::log($e);
+                exit(250);
+            }
+	} else {
+	    trigger_error('Call to undefined method '.__CLASS__.'::'.$name.'()', E_USER_ERROR);
+	}
+
+    }
+
     /**
      * Construct.
      *


### PR DESCRIPTION
Protocols are implemented as static classes and are used as filters, without inheritance.
As a result - it's impossible to implement protocol specific functions in current architecture.

BUT i needed a support of subprotocols in WebService client (plan to implement MQTT over WebSocket on Workerman), as a result - need to pass some parameters, but it's impossible.
The same issue will be with any other protocol specific params (like authentication info and so on).

As s solution - i added magic function into TcpConnection.php (can be implemented in the same way for UDP) and added functions for setting client WS Subprocol request and for getting server Subprotocol reply.

I tested this patch on my test environment and it works as needed.