### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Workerman is an asynchronous event driven PHP framework with high performance for easily building fast, scalable network applications. Supports HTTP, Websocket, SSL and other custom protocols. Supports libevent, [HHVM](https://github.com/facebook/hhvm) , [ReactPHP](https://github.com/reactphp/react).
 
 ## Requires
-PHP 5.3 or Higher  
+PHP 7 or Higher  
 A POSIX compatible operating system (Linux, OSX, BSD)  
 POSIX and PCNTL extensions for PHP  
 


### PR DESCRIPTION
I note that, at least begin with v3.3.3, workerman had used features supported by php7 in many places  like \Error class, although it may not be triggered.

An example:
```
        if ($this->onConnect) {
            try {
                call_user_func($this->onConnect, $connection);
            } catch (\Exception $e) {
                self::log($e);
                exit(250);
            } catch (\Error $e) {
                self::log($e);
                exit(250);
            }
        }
```

doc： http://php.net/manual/en/class.error.php