### PR TITLE
add the yield mode

### DIFF
--- a/Connection/AsyncTcpConnection.php
+++ b/Connection/AsyncTcpConnection.php
@@ -159,7 +159,7 @@ class AsyncTcpConnection extends TcpConnection
         } else {
             $this->transport = self::$_builtinTransports[$scheme];
         }
-        $this->connecid = $connectid;
+        $this->connectid = $connectid;
         // For statistics.
         self::$statistics['connection_count']++;
         $this->maxSendBufferSize        = self::$defaultMaxSendBufferSize;

--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -298,7 +298,7 @@ class TcpConnection extends ConnectionInterface
         if (function_exists('stream_set_read_buffer')) {
             stream_set_read_buffer($this->_socket, 0);
         }
-        Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ, array($this, 'baseRead'));
+        Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ, array($this,'baseRead'),array($this->_id));
         $this->maxSendBufferSize = self::$defaultMaxSendBufferSize;
         $this->_remoteAddress    = $remote_address;
         static::$connections[$this->id] = $this;
@@ -359,11 +359,11 @@ class TcpConnection extends ConnectionInterface
         // Attempt to send data directly.
         if ($this->_sendBuffer === '') {
             $len = @fwrite($this->_socket, $send_buffer, 8192);
-            // send successful.
-            if ($len === strlen($send_buffer)) {
-                $this->bytesWritten += $len;
-                return true;
-            }
+//            // send successful.
+//            if ($len === strlen($send_buffer)) {
+//                $this->bytesWritten += $len;
+//                return true;
+//            }
             // Send only part of the data.
             if ($len > 0) {
                 $this->_sendBuffer = substr($send_buffer, $len);
@@ -388,7 +388,7 @@ class TcpConnection extends ConnectionInterface
                 }
                 $this->_sendBuffer = $send_buffer;
             }
-            Worker::$globalEvent->add($this->_socket, EventInterface::EV_WRITE, array($this, 'baseWrite'));
+            Worker::$globalEvent->add($this->_socket, EventInterface::EV_WRITE, array($this, 'baseWrite'),array($this->_id));
             // Check if the send buffer will be full.
             $this->checkBufferWillFull();
             return null;
@@ -546,7 +546,7 @@ class TcpConnection extends ConnectionInterface
     public function resumeRecv()
     {
         if ($this->_isPaused === true) {
-            Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ, array($this, 'baseRead'));
+            Worker::$globalEvent->add($this->_socket, EventInterface::EV_READ,array($this, 'baseRead'),array($this->_id));
             $this->_isPaused = false;
             $this->baseRead($this->_socket, false);
         }
@@ -588,7 +588,7 @@ class TcpConnection extends ConnectionInterface
             }
             $this->_sslHandshakeCompleted = true;
             if ($this->_sendBuffer) {
-                Worker::$globalEvent->add($socket, EventInterface::EV_WRITE, array($this, 'baseWrite'));
+                Worker::$globalEvent->add($socket, EventInterface::EV_WRITE,array($this, 'baseWrite'),array($this->_id));
             }
             return;
         }

--- a/Events/Event.php
+++ b/Events/Event.php
@@ -64,7 +64,7 @@ class Event implements EventInterface
     /**
      * @see EventInterface::add()
      */
-    public function add($fd,$flag,$func,$args=array())
+    public function add($fd,$flag,$func,$args = array())
     {
         switch ($flag) {
             case self::EV_SIGNAL:
@@ -91,7 +91,7 @@ class Event implements EventInterface
             default :
                 $fd_key = (int)$fd;
                 //to be  compatible
-                if(empty($args)){
+                if(!$args || empty($args) || !isset($args[1])){
                     $args[1] = $func;
                 }
                 $real_flag = $flag === self::EV_READ ? \Event::READ | \Event::PERSIST : \Event::WRITE | \Event::PERSIST;

--- a/Events/Event.php
+++ b/Events/Event.php
@@ -13,6 +13,7 @@
  */
 namespace Workerman\Events;
 
+use Mockery\Generator\Generator;
 use Workerman\Worker;
 
 /**
@@ -20,6 +21,7 @@ use Workerman\Worker;
  */
 class Event implements EventInterface
 {
+    use scheduler;
     /**
      * Event base.
      * @var object
@@ -50,7 +52,9 @@ class Event implements EventInterface
      * @var int
      */
     protected static $_timerId = 1;
-    
+
+    public $taskMap = [];
+
     /**
      * construct
      * @return void
@@ -59,6 +63,9 @@ class Event implements EventInterface
     {
         $this->_eventBase = new \EventBase();
     }
+
+
+
    
     /**
      * @see EventInterface::add()

--- a/Events/Event.php
+++ b/Events/Event.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * This file is part of workerman.
  *
@@ -26,19 +26,19 @@ class Event implements EventInterface
      * @var object
      */
     protected $_eventBase = null;
-    
+
     /**
      * All listeners for read/write event.
      * @var array
      */
     protected $_allEvents = array();
-    
+
     /**
      * Event listeners of signal.
      * @var array
      */
     protected $_eventSignal = array();
-    
+
     /**
      * All timer event listeners.
      * [func, args, event, flag, time_interval]
@@ -60,11 +60,11 @@ class Event implements EventInterface
     {
         $this->_eventBase = new \EventBase();
     }
-   
+
     /**
      * @see EventInterface::add()
      */
-    public function add($fd, $flag, $func, $args=array())
+    public function add($fd,$flag,$func,$args=array())
     {
         switch ($flag) {
             case self::EV_SIGNAL:
@@ -87,11 +87,15 @@ class Event implements EventInterface
                 }
                 $this->_eventTimer[self::$_timerId] = $event;
                 return self::$_timerId++;
-                
+
             default :
                 $fd_key = (int)$fd;
+                //to be  compatible
+                if(empty($args)){
+                    $args[1] = $func;
+                }
                 $real_flag = $flag === self::EV_READ ? \Event::READ | \Event::PERSIST : \Event::WRITE | \Event::PERSIST;
-                $event = new \Event($this->_eventBase, $fd, $real_flag, $func, $fd);
+                $event = new \Event($this->_eventBase, $fd, $real_flag, array($this,'commonFunc'), $args);
                 if (!$event||!$event->add()) {
                     return false;
                 }
@@ -99,7 +103,7 @@ class Event implements EventInterface
                 return true;
         }
     }
-    
+
     /**
      * @see Events\EventInterface::del()
      */
@@ -138,7 +142,7 @@ class Event implements EventInterface
         }
         return true;
     }
-    
+
     /**
      * Timer callback.
      * @param null $fd
@@ -148,7 +152,7 @@ class Event implements EventInterface
     public function timerCallback($fd, $what, $param)
     {
         $timer_id = $param[4];
-        
+
         if ($param[2] === self::EV_TIMER_ONCE) {
             $this->_eventTimer[$timer_id]->del();
             unset($this->_eventTimer[$timer_id]);
@@ -164,9 +168,9 @@ class Event implements EventInterface
             exit(250);
         }
     }
-    
+
     /**
-     * @see Events\EventInterface::clearAllTimer() 
+     * @see Events\EventInterface::clearAllTimer()
      * @return void
      */
     public function clearAllTimer()
@@ -176,7 +180,7 @@ class Event implements EventInterface
         }
         $this->_eventTimer = array();
     }
-     
+
 
     /**
      * @see EventInterface::loop()

--- a/Events/Event.php
+++ b/Events/Event.php
@@ -60,9 +60,6 @@ class Event implements EventInterface
     {
         $this->_eventBase = new \EventBase();
     }
-
-
-
    
     /**
      * @see EventInterface::add()

--- a/Events/Event.php
+++ b/Events/Event.php
@@ -13,7 +13,6 @@
  */
 namespace Workerman\Events;
 
-use Mockery\Generator\Generator;
 use Workerman\Worker;
 
 /**
@@ -52,8 +51,6 @@ class Event implements EventInterface
      * @var int
      */
     protected static $_timerId = 1;
-
-    public $taskMap = [];
 
     /**
      * construct

--- a/Events/Event.php
+++ b/Events/Event.php
@@ -20,7 +20,7 @@ use Workerman\Worker;
  */
 class Event implements EventInterface
 {
-    use scheduler;
+    use Scheduler;
     /**
      * Event base.
      * @var object

--- a/Events/Libevent.php
+++ b/Events/Libevent.php
@@ -100,7 +100,8 @@ class Libevent implements EventInterface
             default :
                 $fd_key    = (int)$fd;
                 $real_flag = $flag === self::EV_READ ? EV_READ | EV_PERSIST : EV_WRITE | EV_PERSIST;
-                if(empty($args)){
+
+                if(!$args || empty($args) || !isset($args[1])){
                     $args[1] = $func;
                 }
                 $event = event_new();

--- a/Events/Libevent.php
+++ b/Events/Libevent.php
@@ -100,10 +100,12 @@ class Libevent implements EventInterface
             default :
                 $fd_key    = (int)$fd;
                 $real_flag = $flag === self::EV_READ ? EV_READ | EV_PERSIST : EV_WRITE | EV_PERSIST;
-
+                if(empty($args)){
+                    $args[1] = $func;
+                }
                 $event = event_new();
 
-                if (!event_set($event, $fd, $real_flag, $func, null)) {
+                if (!event_set($event, $fd, $real_flag,  array($this,'commonFunc'), $args)) {
                     return false;
                 }
 

--- a/Events/Libevent.php
+++ b/Events/Libevent.php
@@ -20,6 +20,7 @@ use Workerman\Worker;
  */
 class Libevent implements EventInterface
 {
+    use scheduler;
     /**
      * Event base.
      *

--- a/Events/Libevent.php
+++ b/Events/Libevent.php
@@ -20,7 +20,7 @@ use Workerman\Worker;
  */
 class Libevent implements EventInterface
 {
-    use scheduler;
+    use Scheduler;
     /**
      * Event base.
      *

--- a/Events/Scheduler.php
+++ b/Events/Scheduler.php
@@ -23,7 +23,7 @@ trait Scheduler
      * @param $fd
      * @param $id
      */
-    public function commonFunc($fd,$connect_id){
+    public function commonFunc($fd,$what,$connect_id){
         $task = $func = $this->taskMap[$connect_id];
         if($task instanceof Task){
             $task->exec();
@@ -48,7 +48,7 @@ trait Scheduler
             case 'event':
                 $fd_key = (int)$fd;
                 $real_flag = $flag === self::EV_READ ? \Event::READ | \Event::PERSIST : \Event::WRITE | \Event::PERSIST;
-                $event = new \Event($this->_eventBase, $fd, $real_flag, array($this,'commonFunc'), array($fd,$connect_id));
+                $event = new \Event($this->_eventBase, $fd, $real_flag, array($this,'commonFunc'), $connect_id);
                 if (!$event||!$event->add()) {
                     return false;
                 }
@@ -58,7 +58,7 @@ trait Scheduler
                 $fd_key    = (int)$fd;
                 $real_flag = $flag === self::EV_READ ? EV_READ | EV_PERSIST : EV_WRITE | EV_PERSIST;
                 $event = event_new();
-                if (!event_set($event, $fd, $real_flag, array($this,'commonFunc'), array($fd,$connect_id))) {
+                if (!event_set($event, $fd, $real_flag, array($this,'commonFunc'), $connect_id)) {
                     return false;
                 }
                 if (!event_base_set($event, $this->_eventBase)) {

--- a/Events/Scheduler.php
+++ b/Events/Scheduler.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * because the loop function is in the event ext.so we should Integrate scheduler into event.
+ * when the socket is ready.wo should get the connectid.so that wo can get the task too.
+ */
+namespace Workerman\Events;
+
+use Workerman\lib\Task;
+
+trait scheduler
+{
+    /**
+     * id=>task
+     * or you can use it like id=>func.but i suggest you use old function(addEvent)
+     *
+     * @var array
+     */
+    public $taskMap = [];
+
+
+    /**
+     * when the socket is ready,exec this function.
+     * @param $fd
+     * @param $id
+     */
+    public function commonFunc($fd,$connect_id){
+        $task = $func = $this->taskMap[$connect_id];
+        if($task instanceof Task){
+            $task->exec();
+            if($task->isFinished()){
+                unset($this->taskMap[$connect_id]);
+            }
+        }else{
+            $func($fd,$connect_id);
+        }
+    }
+
+    /**
+     * add fd to react.event is best
+     * @param $fd
+     * @param $flag
+     * @param $connect_id
+     * @return bool
+     */
+    public function addTaskEvent($fd,$flag,$connect_id,$event = 'event',$func = NULL){
+        //$this->taskMap[$connect_id] = $func; //you should use old function
+        switch ($event){
+            case 'event':
+                $fd_key = (int)$fd;
+                $real_flag = $flag === self::EV_READ ? \Event::READ | \Event::PERSIST : \Event::WRITE | \Event::PERSIST;
+                $event = new \Event($this->_eventBase, $fd, $real_flag, array($this,'commonFunc'), array($fd,$connect_id));
+                if (!$event||!$event->add()) {
+                    return false;
+                }
+                $this->_allEvents[$fd_key][$flag] = $event;
+                return true;
+            case 'libevent':
+                $fd_key    = (int)$fd;
+                $real_flag = $flag === self::EV_READ ? EV_READ | EV_PERSIST : EV_WRITE | EV_PERSIST;
+                $event = event_new();
+                if (!event_set($event, $fd, $real_flag, array($this,'commonFunc'), array($fd,$connect_id))) {
+                    return false;
+                }
+                if (!event_base_set($event, $this->_eventBase)) {
+                    return false;
+                }
+
+                if (!event_add($event)) {
+                    return false;
+                }
+                $this->_allEvents[$fd_key][$flag] = $event;
+
+                return true;
+
+        }
+
+    }
+}

--- a/Events/Scheduler.php
+++ b/Events/Scheduler.php
@@ -7,7 +7,7 @@ namespace Workerman\Events;
 
 use Workerman\lib\Task;
 
-trait scheduler
+trait Scheduler
 {
     /**
      * id=>task

--- a/Lib/Task.php
+++ b/Lib/Task.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * abstract task from Generator yield
+ */
+namespace Workerman\Lib;
+use \Generator;
+
+class Task
+{
+    private $coroutine;
+    private $beforeFirstYield = true;
+    private $sendValue = null;
+
+
+    public function __construct($taskid,Generator $coroutine)
+    {
+        $this->coroutine = $coroutine;
+    }
+
+
+    public function setSendValue($sendValue) {
+        $this->sendValue = $sendValue;
+    }
+
+    public function exec(){
+        if($this->beforeFirstYield){
+            $this->beforeFirstYield = false;
+            $res =  $this->coroutine->current();
+            $this->sendValue = $res;
+            return $res;
+        }else{
+            $retval =  $this->coroutine->send($this->sendValue);
+            $this->sendValue = $retval;
+            return $retval;
+        }
+    }
+
+    public function isFinished() {
+        return !$this->coroutine->valid();
+    }
+
+}

--- a/Lib/Task.php
+++ b/Lib/Task.php
@@ -12,7 +12,7 @@ class Task
     private $sendValue = null;
 
 
-    public function __construct($taskid,Generator $coroutine)
+    public function __construct(Generator $coroutine)
     {
         $this->coroutine = $coroutine;
     }

--- a/Worker.php
+++ b/Worker.php
@@ -2164,7 +2164,7 @@ class Worker
             try {
                 //if the mode is yield\the connection should be Generator
                 if($this->isYield){
-                    $task = new Task($this->onConnect($new_socket,$connection));
+                    $task = new Task(($this->onConnect)($new_socket,$connection));
                     self::$globalEvent->taskMap[$connection->id] = $task;
                 }else{
                     call_user_func($this->onConnect, $connection);

--- a/Worker.php
+++ b/Worker.php
@@ -2179,8 +2179,6 @@ class Worker
         }
     }
 
-
-
     /**
      * For udp package.
      *

--- a/Worker.php
+++ b/Worker.php
@@ -2164,7 +2164,7 @@ class Worker
             try {
                 //if the mode is yield\the connection should be Generator
                 if($this->isYield){
-                    $task = new Task(($this->onConnect)($new_socket,$connection));
+                    $task = new Task(($this->onConnect)($connection));
                     self::$globalEvent->taskMap[$connection->id] = $task;
                 }else{
                     call_user_func($this->onConnect, $connection);


### PR DESCRIPTION
更改的原理:
将回调函数转化为协程抽象任务、并且随着事件循环依次往下执行，每个请求都有对应的协程任务。
 id -> addTask （生成一个协程任务）

例如一个请求的流程：
1、监听socket、并且加入到事件机制中
2、$new_socket = accept() 获取新的socket、生成一个新的协程对象、和请求ID对应，并且把新的socket加入到事件循环中
3、socket可读->执行协程任务、往下执行、遇到yield、中断、代表一次执行完成、记录状态、
4、上一步的yield 后面一般是阻塞请求、涉及到socket、（mysql、redis、http等）加入事件循环中、
5、循环。

注意：一个请求对应一个大的协程任务、可以用yield from 或者是自己写协程堆栈

