### PR TITLE
Support Fully qualified name for Protocols

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -1928,7 +1928,7 @@ class Worker
             // Check application layer protocol class.
             if (!isset(static::$_builtinTransports[$scheme])) {
                 $scheme         = ucfirst($scheme);
-                $this->protocol = '\\Protocols\\' . $scheme;
+                $this->protocol = substr($scheme,0,1)==='\\'?$scheme:'\\Protocols\\' . $scheme;
                 if (!class_exists($this->protocol)) {
                     $this->protocol = "\\Workerman\\Protocols\\$scheme";
                     if (!class_exists($this->protocol)) {


### PR DESCRIPTION
The changes allow us to use fully qualified name for protocol class , it is not required to be in `Protocols` namespace