### PR TITLE
Worker: removing unnecessary OS comparison

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -552,13 +552,11 @@ class Worker
             }
 
             // Get unix user of the worker process.
-            if (static::$_OS === 'linux') {
-                if (empty($worker->user)) {
-                    $worker->user = static::getCurrentUser();
-                } else {
-                    if (posix_getuid() !== 0 && $worker->user != static::getCurrentUser()) {
-                        static::log('Warning: You must have the root privileges to change uid and gid.');
-                    }
+            if (empty($worker->user)) {
+                $worker->user = static::getCurrentUser();
+            } else {
+                if (posix_getuid() !== 0 && $worker->user != static::getCurrentUser()) {
+                    static::log('Warning: You must have the root privileges to change uid and gid.');
                 }
             }
 


### PR DESCRIPTION
It has been done at the [beginning](https://github.com/walkor/Workerman/blob/master/Worker.php#L533) of `initWorkers()`  function.