### PR TITLE
 add Custom 404 page and Custom Headers for WebServer

### DIFF
--- a/WebServer.php
+++ b/WebServer.php
@@ -47,12 +47,12 @@ class WebServer extends Worker
      * Add virtual host.
      *
      * @param string $domain
-     * @param string $root_path
+     * @param string $config
      * @return void
      */
-    public function addRoot($domain, $root_path)
+    public function addRoot($domain, $config)
     {
-        $this->serverRoot[$domain] = $root_path;
+        $this->serverRoot[$domain] = $config;
     }
 
     /**
@@ -164,10 +164,12 @@ class WebServer extends Worker
             $workerman_file_extension = 'php';
         }
 
-        $workerman_root_dir = isset($this->serverRoot[$_SERVER['SERVER_NAME']]) ? $this->serverRoot[$_SERVER['SERVER_NAME']] : current($this->serverRoot);
-
+        $workerman_siteConfig = isset($this->serverRoot[$_SERVER['SERVER_NAME']]) ? $this->serverRoot[$_SERVER['SERVER_NAME']] : current($this->serverRoot);
+		$workerman_root_dir = $workerman_siteConfig['root'];
         $workerman_file = "$workerman_root_dir/$workerman_path";
-
+		if(isset($workerman_siteConfig['additionHeader'])){
+			Http::header($workerman_siteConfig['additionHeader']);
+		}
         if ($workerman_file_extension === 'php' && !is_file($workerman_file)) {
             $workerman_file = "$workerman_root_dir/index.php";
             if (!is_file($workerman_file)) {
@@ -223,7 +225,12 @@ class WebServer extends Worker
         } else {
             // 404
             Http::header("HTTP/1.1 404 Not Found");
-            $connection->close('<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>');
+			if(isset($workerman_siteConfig['custom404'])){
+				$html404 = '<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>';
+			}else{
+				$html404 = file_get_contents($workerman_siteConfig['custom404']);
+			}
+            $connection->close($html404);
             return;
         }
     }

--- a/WebServer.php
+++ b/WebServer.php
@@ -225,10 +225,10 @@ class WebServer extends Worker
         } else {
             // 404
             Http::header("HTTP/1.1 404 Not Found");
-			if(isset($workerman_siteConfig['custom404'])){
-				$html404 = '<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>';
-			}else{
+			if(isset($workerman_siteConfig['custom404']) && file_exists($workerman_siteConfig['custom404'])){
 				$html404 = file_get_contents($workerman_siteConfig['custom404']);
+			}else{
+				$html404 = '<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>';
 			}
             $connection->close($html404);
             return;


### PR DESCRIPTION
change WebServer's Configuration.
use addRoot to add configuration instead of root path.

1.the root path should be ['root'] parameter;
2.['additionHeader'] is an optional config, for example,you can add "access-control-allow-origin:*".
3.['custom404'] is an optional config, for example,you can add "/data/404.html" to customize a 404 Page.