### PR TITLE
Improve the HTTP Sessions management 

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -443,7 +443,7 @@ class Http
         HttpCache::$instance->sessionStarted = true;
         // Generate a SID.
         if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName])) {
-            // Create a new unique session_id and its associated file name.
+            // Create a unique session_id and the associated file name.
             while (true) {
                 $session_id = static::sessionCreateId();
                 if (!is_file($file_name = HttpCache::$sessionPath . '/sess_' . $session_id)) break;

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -345,6 +345,18 @@ class Http
     }
 
     /**
+     * sessionCreateId
+     *
+     * @param string|prefix  $prefix
+     *
+     * @return string
+     */
+    public static function sessionCreateId($prefix = null)
+    {
+        return session_create_id($prefix);
+    }
+
+    /**
      * sessionId
      *
      * @param string  $id
@@ -400,22 +412,6 @@ class Http
     }
 
     /**
-     * sessionStatus
-     *
-     * @return int
-     */
-    public static function sessionStatus()
-    {
-        if (PHP_SAPI != 'cli') {
-            return session_status();
-        }
-        if (!extension_loaded('session')) {
-            return PHP_SESSION_DISABLED;
-        }
-        return static::sessionStarted() ? PHP_SESSION_ACTIVE : PHP_SESSION_NONE;
-    }
-
-    /**
      * sessionStarted
      *
      * @return bool
@@ -449,7 +445,7 @@ class Http
         if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName])) {
             // Create a new unique session_id and its associated file name.
             while (true) {
-                $session_id = session_create_id();
+                $session_id = static::sessionCreateId();
                 if (!is_file($file_name = HttpCache::$sessionPath . '/sess_' . $session_id)) break;
             }
             HttpCache::$instance->sessionFile = $file_name;

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -174,22 +174,8 @@ class Http
                     case 'application/x-www-form-urlencoded':
                         parse_str($http_body, $_POST);
                         break;
-                    case 'application/json':
-                    	$_POST = json_decode($http_body, true);
-                    	break;
                 }
             }
-        }
-        
-        // 解析其他HTTP动作参数
-        if ($_SERVER['REQUEST_METHOD'] != 'GET' && $_SERVER['REQUEST_METHOD'] != "POST") {
-        	$data = array();
-        	if ($_SERVER['HTTP_CONTENT_TYPE'] === "application/x-www-form-urlencoded") {
-        		parse_str($http_body, $data);
-        	} elseif ($_SERVER['HTTP_CONTENT_TYPE'] === "application/json") {
-        		$data = json_decode($http_body, true);
-        	}
-        	$_REQUEST = array_merge($_REQUEST, $data);
         }
 
         // HTTP_RAW_REQUEST_DATA HTTP_RAW_POST_DATA
@@ -205,7 +191,7 @@ class Http
         }
 
         // REQUEST
-        $_REQUEST = array_merge($_GET, $_POST, $_REQUEST);
+        $_REQUEST = array_merge($_GET, $_POST);
 
         // REMOTE_ADDR REMOTE_PORT
         $_SERVER['REMOTE_ADDR'] = $connection->getRemoteIp();
@@ -345,6 +331,89 @@ class Http
     }
 
     /**
+     * sessionId
+     *
+     * @param string  $id
+     *
+     * @return string|null
+     */
+    public static function sessionId($id = null)
+    {
+        if (PHP_SAPI != 'cli') {
+            return $id ? session_id($id) : session_id();
+        }
+        if (static::sessionStarted()) {
+            return str_replace('sess_', '', basename(HttpCache::$instance->sessionFile));
+        }
+        return '';
+    }
+
+    /**
+     * sessionName
+     *
+     * @param string  $name
+     *
+     * @return string
+     */
+    public static function sessionName($name = null)
+    {
+        if (PHP_SAPI != 'cli') {
+            return $name ? session_name($name) : session_name();
+        }
+        $session_name = HttpCache::$sessionName;
+        if ($name && ! static::sessionStarted()) {
+            HttpCache::$sessionName = $name;
+        }
+        return $session_name;
+    }
+
+    /**
+     * sessionSavePath
+     *
+     * @param string  $path
+     *
+     * @return void
+     */
+    public static function sessionSavePath($path = null)
+    {
+        if (PHP_SAPI != 'cli') {
+            return $path ? session_save_path($path) : session_save_path();
+        }
+        if ($path && is_dir($path) && is_writable($path) && !static::sessionStarted()) {
+            HttpCache::$sessionPath = $path;
+        }
+        return HttpCache::$sessionPath;
+    }
+
+    /**
+     * sessionStatus
+     *
+     * @return int
+     */
+    public static function sessionStatus()
+    {
+        if (PHP_SAPI != 'cli') {
+            return session_status();
+        }
+        if (!extension_loaded('session')) {
+            return PHP_SESSION_DISABLED;
+        }
+        return static::sessionStarted() ? PHP_SESSION_ACTIVE : PHP_SESSION_NONE;
+    }
+
+    /**
+     * sessionStarted
+     *
+     * @return bool
+     */
+    public static function sessionStarted()
+    {
+        if (!HttpCache::$instance) return false;
+
+        return HttpCache::$instance->sessionStarted;
+    }
+
+    /**
      * sessionStart
      *
      * @return bool
@@ -363,13 +432,13 @@ class Http
         }
         HttpCache::$instance->sessionStarted = true;
         // Generate a SID.
-        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName])) {
-            $file_name = tempnam(HttpCache::$sessionPath, 'ses');
-            if (!$file_name) {
-                return false;
+        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/sess_' . $_COOKIE[HttpCache::$sessionName])) {
+            // Create a new unique session_id and its associated file name.
+            while (true) {
+                $session_id = session_create_id();
+                if (!is_file($file_name = HttpCache::$sessionPath . '/sess_' . $session_id)) break;
             }
             HttpCache::$instance->sessionFile = $file_name;
-            $session_id                       = substr(basename($file_name), strlen('ses'));
             return self::setcookie(
                 HttpCache::$sessionName
                 , $session_id
@@ -381,7 +450,7 @@ class Http
             );
         }
         if (!HttpCache::$instance->sessionFile) {
-            HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName];
+            HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/sess_' . $_COOKIE[HttpCache::$sessionName];
         }
         // Read session from session file.
         if (HttpCache::$instance->sessionFile) {
@@ -579,8 +648,12 @@ class HttpCache
 
     public static function init()
     {
-        self::$sessionName = ini_get('session.name');
-        self::$sessionPath = @session_save_path();
+        if (!self::$sessionName) {
+            self::$sessionName = ini_get('session.name');
+        }
+        if (!self::$sessionPath) {
+            self::$sessionPath = @session_save_path();
+        }
         if (!self::$sessionPath || strpos(self::$sessionPath, 'tcp://') === 0) {
             self::$sessionPath = sys_get_temp_dir();
         }

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -174,8 +174,22 @@ class Http
                     case 'application/x-www-form-urlencoded':
                         parse_str($http_body, $_POST);
                         break;
+                    case 'application/json':
+                    	$_POST = json_decode($http_body, true);
+                    	break;
                 }
             }
+        }
+
+        // 解析其他HTTP动作参数
+        if ($_SERVER['REQUEST_METHOD'] != 'GET' && $_SERVER['REQUEST_METHOD'] != "POST") {
+        	$data = array();
+        	if ($_SERVER['HTTP_CONTENT_TYPE'] === "application/x-www-form-urlencoded") {
+        		parse_str($http_body, $data);
+        	} elseif ($_SERVER['HTTP_CONTENT_TYPE'] === "application/json") {
+        		$data = json_decode($http_body, true);
+        	}
+        	$_REQUEST = array_merge($_REQUEST, $data);
         }
 
         // HTTP_RAW_REQUEST_DATA HTTP_RAW_POST_DATA
@@ -191,7 +205,7 @@ class Http
         }
 
         // REQUEST
-        $_REQUEST = array_merge($_GET, $_POST);
+        $_REQUEST = array_merge($_GET, $_POST, $_REQUEST);
 
         // REMOTE_ADDR REMOTE_PORT
         $_SERVER['REMOTE_ADDR'] = $connection->getRemoteIp();
@@ -432,7 +446,7 @@ class Http
         }
         HttpCache::$instance->sessionStarted = true;
         // Generate a SID.
-        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/sess_' . $_COOKIE[HttpCache::$sessionName])) {
+        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName])) {
             // Create a new unique session_id and its associated file name.
             while (true) {
                 $session_id = session_create_id();
@@ -450,7 +464,7 @@ class Http
             );
         }
         if (!HttpCache::$instance->sessionFile) {
-            HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/sess_' . $_COOKIE[HttpCache::$sessionName];
+            HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName];
         }
         // Read session from session file.
         if (HttpCache::$instance->sessionFile) {

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -175,21 +175,21 @@ class Http
                         parse_str($http_body, $_POST);
                         break;
                     case 'application/json':
-                    	$_POST = json_decode($http_body, true);
-                    	break;
+                        $_POST = json_decode($http_body, true);
+                        break;
                 }
             }
         }
 
-        // 解析其他HTTP动作参数
+        // Parse other HTTP action parameters
         if ($_SERVER['REQUEST_METHOD'] != 'GET' && $_SERVER['REQUEST_METHOD'] != "POST") {
-        	$data = array();
-        	if ($_SERVER['HTTP_CONTENT_TYPE'] === "application/x-www-form-urlencoded") {
-        		parse_str($http_body, $data);
-        	} elseif ($_SERVER['HTTP_CONTENT_TYPE'] === "application/json") {
-        		$data = json_decode($http_body, true);
-        	}
-        	$_REQUEST = array_merge($_REQUEST, $data);
+            $data = array();
+            if ($_SERVER['HTTP_CONTENT_TYPE'] === "application/x-www-form-urlencoded") {
+                parse_str($http_body, $data);
+            } elseif ($_SERVER['HTTP_CONTENT_TYPE'] === "application/json") {
+                $data = json_decode($http_body, true);
+            }
+            $_REQUEST = array_merge($_REQUEST, $data);
         }
 
         // HTTP_RAW_REQUEST_DATA HTTP_RAW_POST_DATA
@@ -661,9 +661,11 @@ class HttpCache
         if (!self::$sessionName) {
             self::$sessionName = ini_get('session.name');
         }
+
         if (!self::$sessionPath) {
             self::$sessionPath = @session_save_path();
         }
+
         if (!self::$sessionPath || strpos(self::$sessionPath, 'tcp://') === 0) {
             self::$sessionPath = sys_get_temp_dir();
         }

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -368,7 +368,7 @@ class Http
         if (PHP_SAPI != 'cli') {
             return $id ? session_id($id) : session_id();
         }
-        if (static::sessionStarted()) {
+        if (static::sessionStarted() && HttpCache::$instance->sessionFile) {
             return str_replace('sess_', '', basename(HttpCache::$instance->sessionFile));
         }
         return '';

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -442,7 +442,7 @@ class Http
         }
         HttpCache::$instance->sessionStarted = true;
         // Generate a SID.
-        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName])) {
+        if (!isset($_COOKIE[HttpCache::$sessionName]) || !is_file(HttpCache::$sessionPath . '/sess_' . $_COOKIE[HttpCache::$sessionName])) {
             // Create a unique session_id and the associated file name.
             while (true) {
                 $session_id = static::sessionCreateId();
@@ -460,7 +460,7 @@ class Http
             );
         }
         if (!HttpCache::$instance->sessionFile) {
-            HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/ses' . $_COOKIE[HttpCache::$sessionName];
+            HttpCache::$instance->sessionFile = HttpCache::$sessionPath . '/sess_' . $_COOKIE[HttpCache::$sessionName];
         }
         // Read session from session file.
         if (HttpCache::$instance->sessionFile) {


### PR DESCRIPTION
This pull request has as objectives to improve the HTTP Sessions management, making configurable the sessions save path and the name, also improving the security, using a more qualified name for sessions and their files, similar with the native PHP Session API.

A session and its file, before: `VuvLuZ` and `sesVuvLuZ`
A session and its file, after: `1mt5kp8nu3i9nafnfg9su14u84` and `sess_1mt5kp8nu3i9nafnfg9su14u84`

The `Workerman\Protocols\Http` is extended with several obviously named methods:

`sessionCreateId` creates a new session id, using the PHP native function, which is also available in CLI.
`sessionId` returns the session id. This one is partial/read-only implementation, as the native PHP function has also support to set the id.
`sessionName` sets/gets the session name.
`sessionSavePath` sets/gets the sessions save path.

Additionally, there is the helper method `sessionStarted`, which returns true when the Workerman's session is started.