### PR TITLE
Require pcntl and posix extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "source": "https://github.com/walkor/workerman"
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "ext-pcntl": "*",
+        "ext-posix": "*"
     },
     "suggest": {
         "ext-event": "For better performance. "


### PR DESCRIPTION
Running `composer check-platform-reqs` on a project that has workerman dependency does not list pcntl and posix extensions though `Worker.php` contains [pcntl](https://github.com/walkor/Workerman/blob/master/Worker.php#L933) and [posix](https://github.com/walkor/Workerman/blob/master/Worker.php#L581) calls.