### PR TITLE
Fix for DELETE requests that keep the connection hanging

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -73,7 +73,7 @@ class Http
             $content_length = isset($match[1]) ? $match[1] : 0;
             return $content_length + strlen($header) + 4;
         }
-        return 0;
+        return $method === 'DELETE' ? strlen($header) + 4 : 0;
     }
 
     /**


### PR DESCRIPTION
When a `DELETE` request is made without **Content-Length** header, it makes the connection hanging without a response

This commit makes sure we don't return 0 for **getRequestSize** method when it is a delete request.

Following request is an example to reproduce this issue

```
DELETE /examples/_007_crud/authors/1 HTTP/1.1
Content-Type: application/x-www-form-urlencoded
Host: localhost:8080
Connection: close
```

you can test it with the following example

```php
require_once __DIR__ . '/vendor/autoload.php';
use Workerman\Worker;

// #### http worker ####
$http_worker = new Worker("http://0.0.0.0:8080");

// 4 processes
$http_worker->count = 4;

// Emitted when data received
$http_worker->onMessage = function($connection, $data)
{
    // $_GET, $_POST, $_COOKIE, $_SESSION, $_SERVER, $_FILES are available
    var_dump($_GET, $_POST, $_COOKIE, $_SESSION, $_SERVER, $_FILES);
    // send data to client
    $connection->send("hello world \n");
};

// run all workers
Worker::runAll();
