### PR TITLE
Few fixes

### DIFF
--- a/WebServer.php
+++ b/WebServer.php
@@ -237,7 +237,7 @@ class WebServer extends Worker
 		    if  ($this->onNotFound !== null) {
 		        // because we can not call directly a member variable as a function (at least under PHP 7.2)
 		        $notFoundFunction = $this->onNotFound;
-		        $notFoundFunction($connection);
+                call_user_func_array($notFoundFunction, array(&$connection));
 		        return;
             }
             // else we use normal webserver 404
@@ -276,8 +276,9 @@ class WebServer extends Worker
         }
         $file_size = filesize($file_path);
         $file_info = pathinfo($file_path);
-        $extension = isset($file_info['extension']) ? $file_info['extension'] : '';
-        $file_name = isset($file_info['filename']) ? $file_info['filename'] : '';
+        $ext = explode(".", $file_path); $ext = $ext[count($ext) - 1];
+        $extension = isset($file_info['extension']) ? $file_info['extension'] : $ext;
+        $file_name = (isset($file_info['filename']) ? $file_info['filename'] : '') . "." . $extension;
         $header = "HTTP/1.1 200 OK\r\n";
         if (isset(self::$mimeTypeMap[$extension])) {
             $header .= "Content-Type: " . self::$mimeTypeMap[$extension] . "\r\n";

--- a/WebServer.php
+++ b/WebServer.php
@@ -44,6 +44,12 @@ class WebServer extends Worker
     protected $_onWorkerStart = null;
 
     /**
+     * Used to display a custom php script if no files were found using the webserver.
+     *
+     * @var callback
+     */
+    public $onNotFound = null;
+    /**
      * Add virtual host.
      *
      * @param string $domain
@@ -59,16 +65,17 @@ class WebServer extends Worker
     }
 
     /**
-     * Construct.
-     *
+     * WebServer constructor.
      * @param string $socket_name
-     * @param array  $context_option
+     * @param array $context_option
+     * @param null $onNotFound
      */
-    public function __construct($socket_name, $context_option = array())
+    public function __construct($socket_name, $context_option = array(), $onNotFound = null)
     {
         list(, $address) = explode(':', $socket_name, 2);
         parent::__construct('http:' . $address, $context_option);
         $this->name = 'WebServer';
+        $this->onNotFound = $onNotFound;
     }
 
     /**
@@ -226,15 +233,24 @@ class WebServer extends Worker
             // Send file to client.
             return self::sendFile($connection, $workerman_file);
         } else {
-            // 404
-            Http::header("HTTP/1.1 404 Not Found");
-			if(isset($workerman_siteConfig['custom404']) && file_exists($workerman_siteConfig['custom404'])){
-				$html404 = file_get_contents($workerman_siteConfig['custom404']);
-			}else{
-				$html404 = '<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>';
-			}
-            $connection->close($html404);
-            return;
+		    // if WebServer::onNotFound callback was given
+		    if  ($this->onNotFound !== null) {
+		        // because we can not call directly a member variable as a function (at least under PHP 7.2)
+		        $notFoundFunction = $this->onNotFound;
+		        $notFoundFunction($connection);
+		        return;
+            }
+            // else we use normal webserver 404
+            else {
+                Http::header("HTTP/1.1 404 Not Found");
+                if(isset($workerman_siteConfig['custom404']) && file_exists($workerman_siteConfig['custom404'])){
+                    $html404 = file_get_contents($workerman_siteConfig['custom404']);
+                }else{
+                    $html404 = '<html><head><title>404 File not found</title></head><body><center><h3>404 Not Found</h3></center></body></html>';
+                }
+                $connection->close($html404);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
I fixed an error that caused my windows 10 server to crash when using         
`Worker::$eventLoopClass = '\Workerman\Events\Ev';` when ev is not avaiable. 

I also fixed a small line in WebServer that now allow custom file extension even when pathinfo() is not returning the extension 