### PR TITLE
Fix PHP 7.3 warning: "continue" targeting switch is equivalent to "break"

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -565,7 +565,7 @@ class Http
                                 'file_data' => $boundary_value,
                                 'file_size' => strlen($boundary_value),
                             );
-                            continue;
+                            continue 2;
                         } // Is post field.
                         else {
                             // Parse $_POST.


### PR DESCRIPTION
It looks like the original intention of this `continue` is targeting line 554 (`foreach`) so I change it into `continue 2`.