### PR TITLE
fix duplicate EV_TIMER_ONCE id

### DIFF
--- a/Events/Swoole.php
+++ b/Events/Swoole.php
@@ -23,6 +23,8 @@ class Swoole implements EventInterface
 
     protected $_timerOnceMap = array();
 
+    protected $mapId = 0;
+
     protected $_fd = array();
 
     // milisecond
@@ -55,7 +57,10 @@ class Swoole implements EventInterface
             case self::EV_TIMER:
             case self::EV_TIMER_ONCE:
                 $method = self::EV_TIMER == $flag ? 'tick' : 'after';
-                $mapId = count($this->_timerOnceMap);
+                if ($this->mapId > PHP_INT_MAX) {
+                    $this->mapId = 0;
+                }
+                $mapId = $this->mapId++;
                 $timer_id = Timer::$method($fd * 1000,
                     function ($timer_id = null) use ($func, $args, $mapId) {
                         call_user_func_array($func, $args);


### PR DESCRIPTION
EV_TIMER_ONCE timer id must be removed from $_timer when callback finished.The timer id is saved in $_timerOnceMap.This patch fix $_timerOnceMap confusion in some condition.