### PR TITLE
Remove forced ws client header 'Origin'.

### DIFF
--- a/Protocols/Ws.php
+++ b/Protocols/Ws.php
@@ -234,7 +234,7 @@ class Ws
         }
         $payload = (string)$payload;
         if (empty($connection->handshakeStep)) {
-            self::sendHandshake($connection);
+            static::sendHandshake($connection);
         }
         $mask = 1;
         $mask_key = "\x00\x00\x00\x00";
@@ -330,7 +330,7 @@ class Ws
      */
     public static function onConnect($connection)
     {
-        self::sendHandshake($connection);
+        static::sendHandshake($connection);
     }
 
     /**

--- a/Protocols/Ws.php
+++ b/Protocols/Ws.php
@@ -383,7 +383,7 @@ class Ws
         (!preg_match("/\nHost:/i", $user_header_str) ? "Host: $host\r\n" : '').
         "Connection: Upgrade\r\n".
         "Upgrade: websocket\r\n".
-        "Origin: ". (isset($connection->websocketOrigin) ? $connection->websocketOrigin : '*') ."\r\n".
+        (isset($connection->websocketOrigin) ? "Origin: ".$connection->websocketOrigin."\r\n":'').
         (isset($connection->WSClientProtocol)?"Sec-WebSocket-Protocol: ".$connection->WSClientProtocol."\r\n":'').
         "Sec-WebSocket-Version: 13\r\n".
         "Sec-WebSocket-Key: " . $connection->websocketSecKey . $user_header_str . "\r\n\r\n";


### PR DESCRIPTION
This is not needed in common cases and may cause 4xx response.
The default value '*' is also invalid.