### PR TITLE
Discard sending data when status is connecting on close.

### DIFF
--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -836,6 +836,10 @@ class TcpConnection extends ConnectionInterface
      */
     public function close($data = null, $raw = false)
     {
+        if($this->_status === self::STATUS_CONNECTING){
+            $this->destroy();
+            return;
+        }
         if ($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED) {
             return;
         } else {


### PR DESCRIPTION
在业务逻辑复杂的情况下可能发生demo中的情况，导致出现大量CLOSING的连接无法释放，简单的复现方法如下
```php
use Workerman\Connection\AsyncTcpConnection;
use Workerman\Connection\TcpConnection;
use Workerman\Worker;

include __DIR__ . '/vendor/autoload.php';

$worker = new Worker('tcp://0.0.0.0:1082');
$worker->onWorkerStart = function ($worker) {
    $connection = new AsyncTcpConnection('tcp://127.0.0.1:1082');
    $connection->connect();
    $connection->close('aa');
};
$worker->onConnect = function (TcpConnection $connection) {
    $connection->close();
};
Worker::runAll();
```
php test.php connections 可以看到有问题的连接