### PR TITLE
Bump websocket decode performance to %40000 or more in heavy traffic.

### DIFF
--- a/Protocols/Websocket.php
+++ b/Protocols/Websocket.php
@@ -304,7 +304,6 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
      */
     public static function decode($buffer, ConnectionInterface $connection)
     {
-        $masks = $data = $decoded = '';
         $len = ord($buffer[1]) & 127;
         if ($len === 126) {
             $masks = substr($buffer, 4, 4);
@@ -318,9 +317,9 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
                 $data  = substr($buffer, 6);
             }
         }
-        for ($index = 0; $index < strlen($data); $index++) {
-            $decoded .= $data[$index] ^ $masks[$index % 4];
-        }
+        $dataLength = strlen($data);
+        $masks = str_repeat($masks, floor($dataLength / 4)) . substr($masks, 0, $dataLength % 4);
+        $decoded = $data ^ $masks;
         if ($connection->websocketCurrentFrameLength) {
             $connection->websocketDataBuffer .= $decoded;
             return $connection->websocketDataBuffer;


### PR DESCRIPTION
流量大的时候Websocket协议解析有性能问题，导致占用大量cpu，优化之后性能提升40000%，cpu使用率从70%降低到2%。
详情看xhprof中Websocket::decode()
优化前：
![11](https://user-images.githubusercontent.com/7401387/61928245-70022280-afaa-11e9-864f-a05de981048d.png)
![1](https://user-images.githubusercontent.com/7401387/61928249-71cbe600-afaa-11e9-9a22-0d42897d2153.png)

优化后：
![22](https://user-images.githubusercontent.com/7401387/61928258-78f2f400-afaa-11e9-9623-63be542303f1.png)
![2](https://user-images.githubusercontent.com/7401387/61928264-7b554e00-afaa-11e9-99d5-665c65f835c0.png)
