### PR TITLE
Different protocol has different type for Protocol::encode().Fix ide …

### DIFF
--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -54,7 +54,7 @@ abstract class  ConnectionInterface
     /**
      * Sends data on the connection.
      *
-     * @param string $send_buffer
+     * @param mixed $send_buffer
      * @return void|boolean
      */
     abstract public function send($send_buffer);

--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -328,7 +328,7 @@ class TcpConnection extends ConnectionInterface
     /**
      * Sends data on the connection.
      *
-     * @param string $send_buffer
+     * @param mixed $send_buffer
      * @param bool  $raw
      * @return bool|null
      */


### PR DESCRIPTION
Different protocol has different type for Protocol::encode().Fix ide complain of param type mismatch.
![image](https://user-images.githubusercontent.com/7401387/62272084-d5ec1f80-b46c-11e9-83ca-230d1036d1c7.png)
