### PR TITLE
Change phpdoc callback to callable

### DIFF
--- a/Connection/AsyncTcpConnection.php
+++ b/Connection/AsyncTcpConnection.php
@@ -26,7 +26,7 @@ class AsyncTcpConnection extends TcpConnection
     /**
      * Emitted when socket connection is successfully established.
      *
-     * @var callback
+     * @var callable
      */
     public $onConnect = null;
 

--- a/Connection/AsyncUdpConnection.php
+++ b/Connection/AsyncUdpConnection.php
@@ -25,14 +25,14 @@ class AsyncUdpConnection extends UdpConnection
     /**
      * Emitted when socket connection is successfully established.
      *
-     * @var callback
+     * @var callable
      */
     public $onConnect = null;
 
     /**
      * Emitted when socket connection closed.
      *
-     * @var callback
+     * @var callable
      */
     public $onClose = null;
 

--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -33,21 +33,21 @@ abstract class  ConnectionInterface
     /**
      * Emitted when data is received.
      *
-     * @var callback
+     * @var callable
      */
     public $onMessage = null;
 
     /**
      * Emitted when the other end of the socket sends a FIN packet.
      *
-     * @var callback
+     * @var callable
      */
     public $onClose = null;
 
     /**
      * Emitted when an error occurs with connection.
      *
-     * @var callback
+     * @var callable
      */
     public $onError = null;
 

--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -67,35 +67,35 @@ class TcpConnection extends ConnectionInterface
     /**
      * Emitted when data is received.
      *
-     * @var callback
+     * @var callable
      */
     public $onMessage = null;
 
     /**
      * Emitted when the other end of the socket sends a FIN packet.
      *
-     * @var callback
+     * @var callable
      */
     public $onClose = null;
 
     /**
      * Emitted when an error occurs with connection.
      *
-     * @var callback
+     * @var callable
      */
     public $onError = null;
 
     /**
      * Emitted when the send buffer becomes full.
      *
-     * @var callback
+     * @var callable
      */
     public $onBufferFull = null;
 
     /**
      * Emitted when the send buffer becomes empty.
      *
-     * @var callback
+     * @var callable
      */
     public $onBufferDrain = null;
 

--- a/WebServer.php
+++ b/WebServer.php
@@ -39,7 +39,7 @@ class WebServer extends Worker
     /**
      * Used to save user OnWorkerStart callback settings.
      *
-     * @var callback
+     * @var callable
      */
     protected $_onWorkerStart = null;
 

--- a/Worker.php
+++ b/Worker.php
@@ -143,63 +143,63 @@ class Worker
     /**
      * Emitted when worker processes start.
      *
-     * @var callback
+     * @var callable
      */
     public $onWorkerStart = null;
 
     /**
      * Emitted when a socket connection is successfully established.
      *
-     * @var callback
+     * @var callable
      */
     public $onConnect = null;
 
     /**
      * Emitted when data is received.
      *
-     * @var callback
+     * @var callable
      */
     public $onMessage = null;
 
     /**
      * Emitted when the other end of the socket sends a FIN packet.
      *
-     * @var callback
+     * @var callable
      */
     public $onClose = null;
 
     /**
      * Emitted when an error occurs with connection.
      *
-     * @var callback
+     * @var callable
      */
     public $onError = null;
 
     /**
      * Emitted when the send buffer becomes full.
      *
-     * @var callback
+     * @var callable
      */
     public $onBufferFull = null;
 
     /**
      * Emitted when the send buffer becomes empty.
      *
-     * @var callback
+     * @var callable
      */
     public $onBufferDrain = null;
 
     /**
      * Emitted when worker processes stoped.
      *
-     * @var callback
+     * @var callable
      */
     public $onWorkerStop = null;
 
     /**
      * Emitted when worker processes get reload signal.
      *
-     * @var callback
+     * @var callable
      */
     public $onWorkerReload = null;
 
@@ -282,14 +282,14 @@ class Worker
     /**
      * Emitted when the master process get reload signal.
      *
-     * @var callback
+     * @var callable
      */
     public static $onMasterReload = null;
 
     /**
      * Emitted when the master process terminated.
      *
-     * @var callback
+     * @var callable
      */
     public static $onMasterStop = null;
 


### PR DESCRIPTION
The correct type-hint is `callable`.

https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#keyword
https://stackoverflow.com/a/21703948
https://www.php.net/manual/en/language.types.callable.php

Also the static analyzers (phpstan, ...) treat the `callback` like a class, that don't exist.

When update workerman to php 5.4, you can type the argument too. `function (callable $a)`
https://secure.php.net/manual/en/functions.arguments.php