### PR TITLE
Improve header creation

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -236,18 +236,8 @@ class Http
      */
     public static function encode($content, TcpConnection $connection)
     {
-        // Default http-code.
-        if (!isset(HttpCache::$header['Http-Code'])) {
-            $header = "HTTP/1.1 200 OK\r\n";
-        } else {
-            $header = HttpCache::$header['Http-Code'] . "\r\n";
-            unset(HttpCache::$header['Http-Code']);
-        }
-
-        // Content-Type
-        if (!isset(HttpCache::$header['Content-Type'])) {
-            $header .= "Content-Type: text/html;charset=utf-8\r\n";
-        }
+        // http-code status line.
+        $header = HttpCache::$status . "\r\n";
 
         // other headers
         foreach (HttpCache::$header as $key => $item) {
@@ -287,23 +277,23 @@ class Http
             \header($content, $replace, $http_response_code);
             return;
         }
+
         if (\strpos($content, 'HTTP') === 0) {
-            $key = 'Http-Code';
-        } else {
+            HttpCache::$status = $content;
+            return true;
+        }
+
             $key = \strstr($content, ":", true);
             if (empty($key)) {
                 return false;
             }
-        }
 
-        if ('location' === \strtolower($key) && !$http_response_code) {
+        if ('location' === \strtolower($key)) {
+            if (!$http_response_code) {
             $http_response_code = 302;
         }
-
-        if ($http_response_code && isset(HttpCache::$codes[$http_response_code])) {
-            HttpCache::$header['Http-Code'] = "HTTP/1.1 $http_response_code " . HttpCache::$codes[$http_response_code];
-            if ($key === 'Http-Code') {
-                return true;
+            if (isset(HttpCache::$codes[$http_response_code])) {
+                HttpCache::$status = "HTTP/1.1 $http_response_code " . HttpCache::$codes[$http_response_code];
             }
         }
 
@@ -667,7 +657,10 @@ class HttpCache
      * @var HttpCache
      */
     public static $instance             = null;
-    public static $header               = array();
+    public static $status               = 'HTTP/1.1 200 OK'; // default status code
+    public static $header               = array(
+                                            'Content-Type' => 'text/html;charset=utf-8' // default Content-Type
+                                            );
     public static $gzip                 = false;
     public static $sessionPath          = '';
     public static $sessionName          = '';


### PR DESCRIPTION
Separate status or entry line from headers. 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#HTTP_Responses

Added defaults.
Faster `Http::header() `and `encode()`.
Also the `Http::header()` separate the 2 exceptions (`HTTP` and `Location`) better.

I wanted to add the status to the `headerRemove()`, but we can remove the status line, only we can change it. We can only remove headers never the status.