### PR TITLE
Separate Set-Cookie from headers

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -248,10 +248,10 @@ class Http
         // other headers
         $header .= \implode("\r\n", HttpCache::$header) . "\r\n";
 
-		    if(HttpCache::$gzip && isset($connection->gzip) && $connection->gzip){
-			      $header .= "Content-Encoding: gzip\r\n";
-			      $content = \gzencode($content,$connection->gzip);
-		    }
+        if(HttpCache::$gzip && isset($connection->gzip) && $connection->gzip){
+                $header .= "Content-Encoding: gzip\r\n";
+                $content = \gzencode($content,$connection->gzip);
+        }
         // header
         $header .= 'Content-Length: ' . \strlen($content) . "\r\n\r\n";
 
@@ -608,8 +608,9 @@ class Http
             return;
         }
 
+        $time_now = \time();
         foreach(glob(HttpCache::$sessionPath.'/ses*') as $file) {
-            if(\is_file($file) && \time() - \filemtime($file) > HttpCache::$sessionGcMaxLifeTime) {
+            if(\is_file($file) && $time_now - \filemtime($file) > HttpCache::$sessionGcMaxLifeTime) {
                 \unlink($file);
             }
         }


### PR DESCRIPTION
for faster encode.

Before we are checking each header in case it is a `Set-Cookie` and array.
Now it's faster.

Also the inspector in browsers have a separate tab for the cookies. 