### PR TITLE
Add .user.ini

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -1,0 +1,31 @@
+; Config PHP for FastCGi, FPM,...  Now in Workerman
+; see http://php.net/manual/en/configuration.file.per-user.php
+; see http://php.net/manual/en/ini.core.php
+; user_ini.filename  // Use allways .user.ini
+; user_ini.cache_ttl // Not used, in Workerman is persistent
+; Place this file at the same level that the start php script file
+; Every start script could have his own .user.ini
+
+display_errors = On
+;html_errors = On
+;error_reporting = -1
+;log_errors = on
+;error_log = /path/to/file
+
+;default_charset = "UTF-8" ; before PHP 5.6
+;date.timezone = "Europe/Madrid"
+
+
+;upload_max_filesize = 1000M
+;post_max_size = 1005M
+;memory_limit = 64M
+;max_execution_time = 120 // Not used in cli mode
+
+;session see http://php.net/manual/en/session.configuration.php
+;session.name = "SSID"
+;session.cookie_httponly = 1 ; No access from DOM (js)
+;session.cookie_secure = 1 ;only send with https
+;session.save_handler=memcache ; handler (redis, rediscluster, memcache, ...) // In new versions of Workerman
+;session.auto_start = 1  ; always start session automatically
+;session.cookie_lifetime = 84600  ; session lifetime to 1 day
+;session.gc_maxlifetime = 84600   ; session lifetime to 1 day

--- a/Lib/Constants.php
+++ b/Lib/Constants.php
@@ -18,6 +18,7 @@
     foreach ($ini as $var => $value) {
         ini_set($var, $value);
     }
+    unset($ini);
 }
 
 /////// Hardcoded defaults

--- a/Lib/Constants.php
+++ b/Lib/Constants.php
@@ -13,12 +13,12 @@
  */
 
  // Init php
- if (file_exists('.user.ini')) {
-    $ini = parse_ini_file('.user.ini');
+ if (file_exists($file = pathinfo($_SERVER['PHP_SELF'], PATHINFO_FILENAME).'.user.ini')) {
+    $ini = parse_ini_file($file);
     foreach ($ini as $var => $value) {
         ini_set($var, $value);
     }
-    unset($ini);
+    unset($ini, $file);
 }
 
 /////// Hardcoded defaults

--- a/Lib/Constants.php
+++ b/Lib/Constants.php
@@ -12,6 +12,16 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+ // Init php
+ if (file_exists('.user.ini')) {
+    $ini = parse_ini_file('.user.ini');
+    foreach ($ini as $var => $value) {
+        ini_set($var, $value);
+    }
+}
+
+/////// Hardcoded defaults
+
 // Display errors.
 ini_set('display_errors', 'on');
 // Reporting all.

--- a/Lib/Constants.php
+++ b/Lib/Constants.php
@@ -18,8 +18,9 @@
     foreach ($ini as $var => $value) {
         ini_set($var, $value);
     }
-    unset($ini, $file);
+    unset($ini);
 }
+unset ($file);
 
 /////// Hardcoded defaults
 

--- a/example.user.ini
+++ b/example.user.ini
@@ -1,10 +1,13 @@
 ; Config PHP for FastCGi, FPM,...  Now in Workerman
 ; see http://php.net/manual/en/configuration.file.per-user.php
 ; see http://php.net/manual/en/ini.core.php
-; user_ini.filename  // Use allways .user.ini
+; user_ini.filename  // Use allways filename-script.user.ini
 ; user_ini.cache_ttl // Not used, in Workerman is persistent
-; Place this file at the same level that the start php script file
-; Every start script could have his own .user.ini
+; filename-sccript.user.ini
+; Example:
+; start.php -> start.user.ini
+
+
 
 display_errors = On
 ;html_errors = On


### PR DESCRIPTION
like in fastcgi, fpm, ...

https://www.php.net/manual/en/configuration.file.per-user.php

In workerman it isn't per directory, It is per start script and it's persistent during execution.
~Only place the` .user.ini` next to the start script.~

The changes are local to the script.

So it's easier than pollute the code with `ini_set()` and don't need to touch the core Workerman.

PD: Perhaps we can use another filename.