### PR TITLE
fix bug

### DIFF
--- a/Lib/Timer.php
+++ b/Lib/Timer.php
@@ -90,6 +90,10 @@ class Timer
             return false;
         }
 
+        if ($args === null) {
+            $args = [];
+        }
+
         if (self::$_event) {
             return self::$_event->add($time_interval,
                 $persistent ? EventInterface::EV_TIMER : EventInterface::EV_TIMER_ONCE, $func, $args);


### PR DESCRIPTION
解决启动报错，错误如下：

`TypeError: Argument 4 passed to Workerman\Events\React\Base::add() must be of the type array, null given, called in /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Lib/Timer.php on line 95 and defined in /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Events/React/Base.php:63
Stack trace:
#0 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Lib/Timer.php(95): Workerman\Events\React\Base->add(10, 16, Object(Closure), NULL)
#1 /private/tmp/stage_srv/socketServer/vendor/workerman/gateway-worker/src/Register.php(100): Workerman\Lib\Timer::add(10, Object(Closure), NULL, false)
#2 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(2441): GatewayWorker\Register->onConnect(Object(Workerman\Connection\TcpConnection))
#3 /private/tmp/stage_srv/socketServer/vendor/react/event-loop/src/ExtEventLoop.php(251): Workerman\Worker->acceptConnection(Resource id #38)
#4 [internal function]: React\EventLoop\ExtEventLoop->React\EventLoop\{closure}(Resource id #38, 2, NULL)
#5 /private/tmp/stage_srv/socketServer/vendor/react/event-loop/src/ExtEventLoop.php(189): EventBase->loop(1)
#6 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Events/React/Base.php(254): React\EventLoop\ExtEventLoop->run()
#7 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Events/React/Base.php(137): Workerman\Events\React\Base->run()
#8 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(2374): Workerman\Events\React\Base->loop()
#9 /private/tmp/stage_srv/socketServer/vendor/workerman/gateway-worker/src/Register.php(86): Workerman\Worker->run()
#10 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1511): GatewayWorker\Register->run()
#11 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1341): Workerman\Worker::forkOneWorkerForLinux(Object(GatewayWorker\Register))
#12 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1315): Workerman\Worker::forkWorkersForLinux()
#13 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1645): Workerman\Worker::forkWorkers()
#14 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1594): Workerman\Worker::monitorWorkersForLinux()
#15 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(534): Workerman\Worker::monitorWorkers()
#16 /private/tmp/stage_srv/socketServer/start.php(37): Workerman\Worker::runAll()
#17 {main}
Worker[25896] process terminated
TypeError: Argument 4 passed to Workerman\Events\React\Base::add() must be of the type array, null given, called in /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Lib/Timer.php on line 95 and defined in /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Events/React/Base.php:63
Stack trace:
#0 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Lib/Timer.php(95): Workerman\Events\React\Base->add(1, 16, Array, NULL)
#1 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Connection/AsyncTcpConnection.php(224): Workerman\Lib\Timer::add(1, Array, NULL, false)
#2 /private/tmp/stage_srv/socketServer/vendor/workerman/gateway-worker/src/BusinessWorker.php(309): Workerman\Connection\AsyncTcpConnection->reconnect(1)
#3 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Connection/TcpConnection.php(947): GatewayWorker\BusinessWorker->GatewayWorker\{closure}(Object(Workerman\Connection\AsyncTcpConnection))
#4 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Connection/TcpConnection.php(596): Workerman\Connection\TcpConnection->destroy()
#5 /private/tmp/stage_srv/socketServer/vendor/react/event-loop/src/ExtEventLoop.php(251): Workerman\Connection\TcpConnection->baseRead(Resource id #59)
#6 [internal function]: React\EventLoop\ExtEventLoop->React\EventLoop\{closure}(Resource id #59, 2, NULL)
#7 /private/tmp/stage_srv/socketServer/vendor/react/event-loop/src/ExtEventLoop.php(189): EventBase->loop(1)
#8 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Events/React/Base.php(254): React\EventLoop\ExtEventLoop->run()
#9 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Events/React/Base.php(137): Workerman\Events\React\Base->run()
#10 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(2374): Workerman\Events\React\Base->loop()
#11 /private/tmp/stage_srv/socketServer/vendor/workerman/gateway-worker/src/BusinessWorker.php(197): Workerman\Worker->run()
#12 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1511): GatewayWorker\BusinessWorker->run()
#13 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1341): Workerman\Worker::forkOneWorkerForLinux(Object(GatewayWorker\BusinessWorker))
#14 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1315): Workerman\Worker::forkWorkersForLinux()
#15 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1645): Workerman\Worker::forkWorkers()
#16 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(1594): Workerman\Worker::monitorWorkersForLinux()
#17 /private/tmp/stage_srv/socketServer/vendor/workerman/workerman/Worker.php(534): Workerman\Worker::monitorWorkers()
#18 /private/tmp/stage_srv/socketServer/start.php(37): Workerman\Worker::runAll()
#19 {main}
Worker[25877] process terminated`

