### PR TITLE
保存parseSocketAddress的结果存储到_localSocket 

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -2191,7 +2191,7 @@ class Worker
 
         if (!$this->_mainSocket) {
 
-            $local_socket = !empty($this->_localSocket)?$this->_localSocket:$this->parseSocketAddress();
+            $local_socket = !empty($this->_localSocket) ? $this->_localSocket : $this->parseSocketAddress();
 
             // Flag.
             $flags = $this->transport === 'udp' ? STREAM_SERVER_BIND : STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;

--- a/Worker.php
+++ b/Worker.php
@@ -321,6 +321,13 @@ class Worker
      */
     protected $_socketName = '';
 
+    /** parse from _socketName avoid parse again in master or worker
+     * LocalSocket The format is like tcp://0.0.0.0:8080
+     * @var string
+     */
+
+    protected $_localSocket=null;
+
     /**
      * Context of socket.
      *
@@ -2159,7 +2166,7 @@ class Worker
         // Context for socket.
         if ($socket_name) {
             $this->_socketName = $socket_name;
-            $this->parseSocketAddress();
+            $this->_localSocket = $this->parseSocketAddress();
             if (!isset($context_option['socket']['backlog'])) {
                 $context_option['socket']['backlog'] = static::DEFAULT_BACKLOG;
             }
@@ -2184,7 +2191,7 @@ class Worker
 
         if (!$this->_mainSocket) {
 
-            $local_socket = $this->parseSocketAddress();
+            $local_socket = !empty($this->_localSocket)?$this->_localSocket:$this->parseSocketAddress();
 
             // Flag.
             $flags = $this->transport === 'udp' ? STREAM_SERVER_BIND : STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;


### PR DESCRIPTION
加一个_localSocket属性， 在new Worker时 把parseSocketAddress的结果存储在_localSocket
省得在mater或者worker里listen()时重复解析

多个worker就可能解析多次，在master里做好后，worker直接继承即可