### PR TITLE
support reloading all worker instances gracefully when new start scripts added

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -678,6 +678,19 @@ class Worker
         }
     }
 
+    /**  
+     * Reload all worker instances.
+     *
+     * @return void
+     */
+    public static function reloadAllWorkers()
+    {    
+        static::init();
+        static::initWorkers();
+        static::displayUI();
+        static::$_status = static::STATUS_RELOADING;
+    }    
+
     /**
      * Get all worker instances.
      *
@@ -697,7 +710,7 @@ class Worker
     {
         return static::$globalEvent;
     }
-    
+
     /**
      * Get main socket resource
      * @return resource


### PR DESCRIPTION
1、issue from:  https://wenda.workerman.net/question/4701

2、finally, the **start.php**  may be look like this:

```
<?php
/**
 * run with command
 * php start.php start
 */

ini_set('display_errors', 'on');
use Workerman\Worker;

// 标记是全局启动
define('GLOBAL_START', 1);

require_once dirname(__FILE__)  .  '/Workerman/Autoloader.php';

function  getStartFiles()
{
    $start_files = [];
    foreach(glob(__DIR__.'/application/start_*.php', GLOB_BRACE) as $start_file)
    {
        $start_files[] = $start_file;
    }

    return $start_files;
}

function  loadStartFiles()
{
    $start_files = getStartFiles();
    foreach($start_files as $start_file)
    {
        require_once $start_file;
    }
}

loadStartFiles();

Worker::$onMasterReload = function(){
    loadStartFiles();
    Worker::reloadAllWorkers();
};

// 运行所有服务
Worker::runAll();
```
3、now, we have some tricks for playing as title described:
（1）assume the base start directory is ```/path/to/application/```
（2）set the callback ```Worker::$onMasterReload``` like the code above 
（3）then we can reload all worker instances gracefully when new start scripts added into the base start directory, of course, it depends on ```php start.php reload``` 
4、the code above seems works well after testing many times, plz give some suggestions, thks.