### PR TITLE
Make Http Request supports application/json

### DIFF
--- a/Protocols/Http/Request.php
+++ b/Protocols/Http/Request.php
@@ -458,8 +458,8 @@ class Request
             $this->_data['post'] = static::$_postCache[$body_buffer];
             return;
         }
-        $content_type = $this->header('content-type');
-        if ($content_type !== null && \preg_match('/boundary="?(\S+)"?/', $content_type, $match)) {
+        $content_type = $this->header('content-type', '');
+        if (\preg_match('/boundary="?(\S+)"?/', $content_type, $match)) {
             $http_post_boundary = '--' . $match[1];
             $this->parseUploadFiles($http_post_boundary);
             return;

--- a/Protocols/Http/Request.php
+++ b/Protocols/Http/Request.php
@@ -464,7 +464,11 @@ class Request
             $this->parseUploadFiles($http_post_boundary);
             return;
         }
-        \parse_str($body_buffer, $this->_data['post']);
+        if (\preg_match('/\bjson\b/i', $content_type)) {
+            $this->_data['post'] = (array) json_decode($body_buffer, true);
+        } else {
+            \parse_str($body_buffer, $this->_data['post']);
+        }
         if ($cacheable) {
             static::$_postCache[$body_buffer] = $this->_data['post'];
             if (\count(static::$_postCache) > 256) {


### PR DESCRIPTION
Before this patch, if the request is a `application/json` payload, `$request->post()` will return something like 

```php
[ "{\"json_key_1\":\"json_value_1\"}" => "" ]
```

People would have to use `json_decode(array_keys()[0], true)` to get the correct parsed POST array. (or parse the raw content)

```php
[ "json_key_1" => "json_value_1" ]
```