### PR TITLE
Fix parse protocol when keepalive

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -125,9 +125,6 @@ class Http
                 }
             }
             return $head_len;
-        } else if ($method !== 'POST' && $method !== 'PUT') {
-            $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
-            return 0;
         }
 
         $header = \substr($recv_buffer, 0, $crlf_pos);


### PR DESCRIPTION
keepalive的前提下：

第一次发起GET请求，带body（虽然不符合规范）

第二次发起请求，协议解析时，会把上一次的body解析到method里
