### PR TITLE
Fix parse protocol when keepalive

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -124,32 +124,27 @@ class Http
                     unset($input[key($input)]);
                 }
             }
-            return $head_len;
         } else if ($method !== 'POST' && $method !== 'PUT') {
             $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
             return 0;
         }
 
         $header = \substr($recv_buffer, 0, $crlf_pos);
-        $length = false;
         if ($pos = \strpos($header, "\r\nContent-Length: ")) {
             $length = $head_len + (int)\substr($header, $pos + 18, 10);
         } else if (\preg_match("/\r\ncontent-length: ?(\d+)/i", $header, $match)) {
             $length = $head_len + $match[1];
+        } else {
+            $length = $head_len;
         }
 
-        if ($length !== false) {
-            if (!isset($recv_buffer[512])) {
-                $input[$recv_buffer] = $length;
-                if (\count($input) > 512) {
-                    unset($input[key($input)]);
-                }
+        if (!isset($recv_buffer[512])) {
+            $input[$recv_buffer] = $length;
+            if (\count($input) > 512) {
+                unset($input[key($input)]);
             }
-            return $length;
         }
-
-        $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
-        return 0;
+        return $length;
     }
 
     /**


### PR DESCRIPTION
<https://github.com/walkor/Workerman/pull/582> 没有严格测试，现在已经重新修改

原写法是GET、OPTIONS、HEAD、DELETE不解析`Content-Length`直接跳过了，会导致keepalive情况下的后续请求解析出错。

会把前一个请求的body内容，当作新的请求数据去解析，然后method就错了。

