### PR TITLE
Optimize the logic of checking whether the master is alive

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -2579,13 +2579,15 @@ class Worker
         }
 
         $cmdline = "/proc/{$master_pid}/cmdline";
-        if (!is_readable($cmdline)) {
+        if (!is_readable($cmdline) || empty(static::$processTitle)) {
             return true;
         }
 
-        $pattern = sprintf('#%s#', preg_quote(static::$processTitle));
-        $subject = file_get_contents($cmdline);
+        $content = file_get_contents($cmdline);
+        if (empty($content)) {
+            return true;
+        }
 
-        return preg_match($pattern, $subject) > 0;
+        return stripos($content, static::$processTitle) !== false;
     }
 }

--- a/Worker.php
+++ b/Worker.php
@@ -2578,11 +2578,14 @@ class Worker
             return false;
         }
 
-        // Master process will send SIGUSR2 signal to all child processes.
-        \posix_kill($master_pid, SIGUSR2);
-        // Sleep 1 second.
-        \sleep(1);
+        $cmdline = "/proc/{$master_pid}/cmdline";
+        if (!is_readable($cmdline)) {
+            return true;
+        }
 
-        return stripos(static::formatStatusData(), 'PROCESS STATUS') !== false;
+        $pattern = sprintf('#%s#', preg_quote(static::$processTitle));
+        $subject = file_get_contents($cmdline);
+
+        return preg_match($pattern, $subject) > 0;
     }
 }


### PR DESCRIPTION
Fixed: #125 

There is a problem: 
if another process starts and the pid is the same as the workerman's old pid, it will receive the SIGUSR2 signal.