### PR TITLE
php7.4 Turn on strict mode declare(strict_types=1);  posix_kill() TypeError

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -981,7 +981,7 @@ class Worker
                 $start_time = \time();
                 // Check master process is still alive?
                 while (1) {
-                    $master_is_alive = $master_pid && \posix_kill($master_pid, 0);
+                    $master_is_alive = $master_pid && \posix_kill((int) $master_pid, 0);
                     if ($master_is_alive) {
                         // Timeout?
                         if (!static::$_gracefulStop && \time() - $start_time >= $timeout) {
@@ -2562,7 +2562,7 @@ class Worker
             return false;
         }
 
-        $master_is_alive = $master_pid && \posix_kill($master_pid, 0) && \posix_getpid() !== $master_pid;
+        $master_is_alive = $master_pid && \posix_kill((int) $master_pid, 0) && \posix_getpid() !== $master_pid;
         if (!$master_is_alive) {
             return false;
         }


### PR DESCRIPTION
## code
```
<?php
declare(strict_types=1);
```

## error
```
  [TypeError]
  posix_kill() expects parameter 1 to be int, string given
```
![image](https://user-images.githubusercontent.com/14959876/114832027-9ad87e00-9e00-11eb-8f2b-eb4c35205ff6.png)

## function.posix-kill.php
![image](https://user-images.githubusercontent.com/14959876/114962751-decd9080-9e9d-11eb-85db-9d2880301948.png)
