### PR TITLE
fix http $request connection is null problem when use swoole event loop #618

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -168,7 +168,7 @@ class Http
         static $requests = array();
         $cacheable = static::$_enableCache && !isset($recv_buffer[512]);
         if (true === $cacheable && isset($requests[$recv_buffer])) {
-            $request = $requests[$recv_buffer];
+            $request = clone $requests[$recv_buffer];
             $request->connection = $connection;
             $connection->__request = $request;
             $request->properties = array();


### PR DESCRIPTION
When use swoole as event loop, and request decode cache enabled, $request->connection may reset to null in Workerman\Protocols\Response::encode during concurrent requests.