### PR TITLE
string pid always not equal int pid

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -908,7 +908,7 @@ class Worker
         static::log("Workerman[$start_file] $command $mode_str");
 
         // Get master process PID.
-        $master_pid      = \is_file(static::$pidFile) ? \file_get_contents(static::$pidFile) : 0;
+        $master_pid      = intval(\is_file(static::$pidFile) ? \file_get_contents(static::$pidFile) : 0);
         // Master is still alive?
         if (static::checkMasterIsAlive($master_pid)) {
             if ($command === 'start') {


### PR DESCRIPTION
file_get_contents拿到的是string型，posix_getpid拿到的是int型，会导致检测进程是否存活出问题

line2565：$master_is_alive = $master_pid && \posix_kill((int) $master_pid, 0) && \posix_getpid() !== $master_pid;