### PR TITLE
fix:last-modified:304 failure

### DIFF
--- a/Protocols/Http/Response.php
+++ b/Protocols/Http/Response.php
@@ -375,7 +375,7 @@ class Response
 
         if (!isset($headers['Last-Modified'])) {
             if ($mtime = \filemtime($file)) {
-                $head .= 'Last-Modified: '.\date('D, d M Y H:i:s', $mtime) . ' ' . \date_default_timezone_get() ."\r\n";
+                $head .= 'Last-Modified: '. \gmdate('D, d M Y H:i:s', $mtime) . ' GMT' . "\r\n";
             }
         }
 


### PR DESCRIPTION
Last-Modified 标准是要 gmt https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Last-Modified

实际测试：

```
HTTP/1.1 200 OK
Server: workerman
Content-Length: 16958
Accept-Ranges: bytes
Connection: keep-alive
Content-Type: image/x-icon
Last-Modified: Tue, 01 Jun 2021 12:10:57 PRC
```

所以提交pr修改
