### PR TITLE
Sometimes i want to change the data before it is sent

### DIFF
--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -304,8 +304,8 @@ class TcpConnection extends ConnectionInterface
     public function send($send_buffer, $raw = false)
     {
         // Sometimes you want to change the data before it is sent, you can define a beforeSend method on the connection to modify the data.
-        if(method_exists($this, "beforeSend")) {
-            $send_buffer = $this->beforeSend($send_buffer);
+        if(property_exists($this, "beforeSend")) {
+            $send_buffer = call_user_func($this->beforeSend, $send_buffer);
         }
 
         if ($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED) {

--- a/Connection/TcpConnection.php
+++ b/Connection/TcpConnection.php
@@ -303,6 +303,11 @@ class TcpConnection extends ConnectionInterface
      */
     public function send($send_buffer, $raw = false)
     {
+        // Sometimes you want to change the data before it is sent, you can define a beforeSend method on the connection to modify the data.
+        if(method_exists($this, "beforeSend")) {
+            $send_buffer = $this->beforeSend($send_buffer);
+        }
+
         if ($this->_status === self::STATUS_CLOSING || $this->_status === self::STATUS_CLOSED) {
             return false;
         }
@@ -676,7 +681,7 @@ class TcpConnection extends ConnectionInterface
             $this->bytesWritten += $len;
             Worker::$globalEvent->del($this->_socket, EventInterface::EV_WRITE);
             $this->_sendBuffer = '';
-            // Try to emit onBufferDrain callback when the send buffer becomes empty. 
+            // Try to emit onBufferDrain callback when the send buffer becomes empty.
             if ($this->onBufferDrain) {
                 try {
                     call_user_func($this->onBufferDrain, $this);


### PR DESCRIPTION
 Sometimes i want to change the data before it is sent, but when i use the pipe method，but when I use the pipe method, I can't modify the data to be sent.

This code comes from [php-http-proxy](https://github.com/walkor/php-http-proxy/blob/master/start.php)
```php
 $srcDomain = 'zg.com:8787';
        $srcDomain = 'a.com';
        $desDomain = 'b.com';
        // Parse http header.
        list($method, $addr, $http_version) = explode(' ', $buffer);

        // Async TCP connection.
        $remote_connection = new AsyncTcpConnection("tcp://127.0.0.1");
        $remote_connection->beforeSend = function ($data) use ($srcDomain, $desDomain) {
            return Str::replace($srcDomain, $desDomain, $data);
        };
        // CONNECT.
        if ($method !== 'CONNECT') {
            $remote_connection->send($buffer);
            // POST GET PUT DELETE etc.
        } else {
            $connection->send("HTTP/1.1 200 Connection Established\r\n\r\n");
        }
        // Pipe.
        $remote_connection ->pipe($connection);
        $connection->pipe($remote_connection);
        $remote_connection->connect();
```