### PR TITLE
Fix PHP 8.1

### DIFF
--- a/Events/Select.php
+++ b/Events/Select.php
@@ -145,7 +145,7 @@ class Select implements EventInterface
                 $select_timeout = ($run_time - \microtime(true)) * 1000000;
                 $select_timeout = $select_timeout <= 0 ? 1 : $select_timeout;
                 if( $this->_selectTimeout > $select_timeout ){ 
-                    $this->_selectTimeout = $select_timeout;   
+                    $this->_selectTimeout = (int) $select_timeout;   
                 }  
                 return $timer_id;
         }
@@ -216,7 +216,7 @@ class Select implements EventInterface
             $timer_id             = $scheduler_data['data'];
             $next_run_time        = -$scheduler_data['priority'];
             $time_now             = \microtime(true);
-            $this->_selectTimeout = ($next_run_time - $time_now) * 1000000;
+            $this->_selectTimeout = (int) (($next_run_time - $time_now) * 1000000);
             if ($this->_selectTimeout <= 0) {
                 $this->_scheduler->extract();
 
@@ -274,7 +274,7 @@ class Select implements EventInterface
                 } catch (\Exception $e) {} catch (\Error $e) {}
 
             } else {
-                $this->_selectTimeout >= 1 && usleep((int)$this->_selectTimeout);
+                $this->_selectTimeout >= 1 && usleep($this->_selectTimeout);
                 $ret = false;
             }
 


### PR DESCRIPTION
Fix Implicit conversion from float xxx to int loses precision.

Turn to int when assigning a variable.