### PR TITLE
Fixed PHP Deprecated:  strlen() in Http:Response

### DIFF
--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -410,7 +410,7 @@ class Response
         }
 
         $reason = $this->_reason ? $this->_reason : static::$_phrases[$this->_status];
-        $body_len = \strlen($this->_body);
+        $body_len = \strlen($this->_body ?? "");
         if (empty($this->_header)) {
             return "HTTP/{$this->_version} {$this->_status} $reason\r\nServer: workerman\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\nConnection: keep-alive\r\n\r\n{$this->_body}";
         }


### PR DESCRIPTION
Correction in passing parameters to \strlen. Passing null for the string type parameter is deprecated.