### PR TITLE
Fix prematurely closing connection in non-keepalive mode

### DIFF
--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -836,11 +836,15 @@ class TcpConnection extends ConnectionInterface
             return;
         }
 
+        $completed = true;
+
         if ($data !== null) {
-            $this->send($data, $raw);
+            $completed = $this->send($data, $raw);
         }
 
-        $this->_status = self::STATUS_CLOSING;
+        if ($completed) {
+            $this->_status = self::STATUS_CLOSING;
+        }
 
         if ($this->_sendBuffer === '') {
             $this->destroy();


### PR DESCRIPTION
send() may send only part of the data, so next time (when EV_WRITE invoked), send() will close connection as it was marked as "closing".
How to reproduce: download 10mb file in non-keepalive mode (Connection: close)