### PR TITLE
Update Worker.php

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -590,6 +590,10 @@ class Worker
         }
 
         if (!\is_file(static::$logFile)) {
+            // if /runtime/logs  default folder not exists
+            if(!is_dir(dirname(static::$logFile))){
+                @mkdir(dirname(static::$logFile),0777,true);
+            }
             \touch(static::$logFile);
             \chmod(static::$logFile, 0622);
         }


### PR DESCRIPTION
防止在serverless部署中，因为runtime需要迁移到/tmp下时(serverless全局仅读，仅/tmp可写)， runtime/logs 不存在时候的报错
 touch(): Unable to create file /app/runtime/logs/workerman.log because No such file or directory in file /app/vendor/workerman/workerman/Worker.php on line 599