### PR TITLE
remove header['server'] for security reasons

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -193,7 +193,7 @@ class Http
                 unset($connection->__header);
             }
             $body_len = \strlen((string)$response);
-            return "HTTP/1.1 200 OK\r\nServer: workerman\r\n{$ext_header}Connection: keep-alive\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\n\r\n$response";
+            return "HTTP/1.1 200 OK\r\n{$ext_header}Connection: keep-alive\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\n\r\n$response";
         }
 
         if (isset($connection->__header)) {

--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -356,10 +356,7 @@ class Response
         $file = $file_info['file'];
         $reason = $this->_reason ?: static::$_phrases[$this->_status];
         $head = "HTTP/{$this->_version} {$this->_status} $reason\r\n";
-        $headers = $this->_header;
-        if (!isset($headers['Server'])) {
-            $head .= "Server: workerman\r\n";
-        }
+        $headers = $this->_header;      
         foreach ($headers as $name => $value) {
             if (\is_array($value)) {
                 foreach ($value as $item) {
@@ -412,14 +409,11 @@ class Response
         $reason = $this->_reason ?: static::$_phrases[$this->_status];
         $body_len = \strlen($this->_body);
         if (empty($this->_header)) {
-            return "HTTP/{$this->_version} {$this->_status} $reason\r\nServer: workerman\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\nConnection: keep-alive\r\n\r\n{$this->_body}";
+            return "HTTP/{$this->_version} {$this->_status} $reason\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\nConnection: keep-alive\r\n\r\n{$this->_body}";
         }
 
         $head = "HTTP/{$this->_version} {$this->_status} $reason\r\n";
-        $headers = $this->_header;
-        if (!isset($headers['Server'])) {
-            $head .= "Server: workerman\r\n";
-        }
+        $headers = $this->_header;       
         foreach ($headers as $name => $value) {
             if (\is_array($value)) {
                 foreach ($value as $item) {

--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -339,7 +339,7 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
             if (\preg_match("/Sec-WebSocket-Key: *(.*?)\r\n/i", $buffer, $match)) {
                 $Sec_WebSocket_Key = $match[1];
             } else {
-                $connection->close("HTTP/1.1 200 WebSocket\r\nServer: workerman/" . Worker::VERSION . "\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1><hr>workerman/" . Worker::VERSION . "</div>",
+                $connection->close("HTTP/1.1 200 WebSocket\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1></div>",
                     true);
                 return 0;
             }
@@ -366,26 +366,15 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
                 $connection->websocketType = static::BINARY_TYPE_BLOB;
             }
 
-            $has_server_header = false;
-
             if (isset($connection->headers)) {
                 if (\is_array($connection->headers)) {
-                    foreach ($connection->headers as $header) {
-                        if (\stripos($header, 'Server:') === 0) {
-                            $has_server_header = true;
-                        }
+                    foreach ($connection->headers as $header) {                       
                         $handshake_message .= "$header\r\n";
                     }
-                } else {
-                    if (\stripos($connection->headers, 'Server:') !== false) {
-                        $has_server_header = true;
-                    }
+                } else {                   
                     $handshake_message .= "$connection->headers\r\n";
                 }
-            }
-            if (!$has_server_header) {
-                $handshake_message .= "Server: workerman/" . Worker::VERSION . "\r\n";
-            }
+            }            
             $handshake_message .= "\r\n";
             // Send handshake response.
             $connection->send($handshake_message, true);
@@ -419,7 +408,7 @@ class Websocket implements \Workerman\Protocols\ProtocolInterface
             return 0;
         }
         // Bad websocket handshake request.
-        $connection->close("HTTP/1.1 200 WebSocket\r\nServer: workerman/" . Worker::VERSION . "\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1><hr>workerman/" . Worker::VERSION . "</div>",
+        $connection->close("HTTP/1.1 200 WebSocket\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1></div>",
             true);
         return 0;
     }


### PR DESCRIPTION
To increase the security of websites, it is better that no one understands what technologies the program uses