### PR TITLE
4.1 修复同时并发执行启动命令时可能会重复启动的问题

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -647,11 +647,13 @@ class Worker
      */
     public static function unlockPid()
     {
-        if ($fd = @\fopen(static::$pidFile . '.lock', 'r')) {
+        \set_error_handler(function () {});
+        if ($fd = \fopen(static::$pidFile . '.lock', 'r')) {
             flock($fd, \LOCK_UN);
             fclose($fd);
             unlink(static::$pidFile . '.lock');
         }
+        \restore_error_handler();
     }
 
     /**


### PR DESCRIPTION
同时向多个控制台发送命令，模拟并发启动，很快复现重复启动了进程的情况：

```php
php s.php start
```


```php
<?php

use Workerman\Worker;

require 'vendor/autoload.php';

for ($i = 0; $i < 200; $i++) {
    $worker                = new Worker();
    $worker->onWorkerStart = function ($worker) use ($i) {
        echo "$i";
    };
}

Worker::runAll();
```

**解决方案：**

对 `parseCommand()` 加文件锁 尽可能的防止并发问题

```php
...

static::log("Workerman[$start_file] $command $mode_str");

if (!static::lockPid()) {
    static::log("Workerman[$start_file] parseCommand running");
    exit;
}

// 这里会有并发问题
// Get master process PID.
$master_pid      = \is_file(static::$pidFile) ? (int)\file_get_contents(static::$pidFile) : 0;

...
```

