### PR TITLE
4.1 修复同时并发执行启动命令时可能会重复启动的问题

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -647,11 +647,13 @@ class Worker
      */
     public static function unlockPid()
     {
-        if ($fd = @\fopen(static::$pidFile . '.lock', 'r')) {
+        \set_error_handler(function () {});
+        if ($fd = \fopen(static::$pidFile . '.lock', 'r')) {
             flock($fd, \LOCK_UN);
             fclose($fd);
             unlink(static::$pidFile . '.lock');
         }
+        \restore_error_handler();
     }
 
     /**


### PR DESCRIPTION
#803

当前环境为 NFS 的话就绕过锁：增加一个属性作为判断呢，默认为 `$isNFS = false` ，如果是 NFS 系统的话，用户自己设置下。