### PR TITLE
Fix bad interpreter: Text file busy

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -634,7 +634,7 @@ class Worker
     protected static function lock($flag = \LOCK_EX)
     {
         static $fd;
-        $fd = $fd ?: \fopen(static::$_startFile, 'a+');
+        $fd = $fd ?: \fopen(__DIR__ . '/../../' . md5(static::$_startFile) . '.lock', 'a+');
         if ($fd) {
             flock($fd, $flag);
         }


### PR DESCRIPTION
如果 PHP 文件本身就是可执行文件：

`test.php`：

```php
#!/usr/bin/env php
<?php
use Workerman\Worker;

require_once __DIR__ . '/vendor/autoload.php';

$worker = new Worker('http://0.0.0.0:8080');
// 运行worker
Worker::runAll();
```

执行：`./test.php start` 后给 `test.php` 加锁期间，如果又执行了 `./test.php` 会提示：`-bash: ./test.php: /usr/bin/env: bad interpreter: Text file busy`
