### PR TITLE
Fix no content-length

### DIFF
--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -117,13 +117,14 @@ class Http
         }
 
         $header = \substr($recv_buffer, 0, $crlf_pos);
-        $has_content_length = false;
         if ($pos = \strpos($header, "\r\nContent-Length: ")) {
             $length = $length + (int)\substr($header, $pos + 18, 10);
             $has_content_length = true;
         } else if (\preg_match("/\r\ncontent-length: ?(\d+)/i", $header, $match)) {
             $length = $length + $match[1];
             $has_content_length = true;
+        } else {
+            $has_content_length = false;
         }
 
         if ($has_content_length) {
@@ -131,9 +132,6 @@ class Http
                 $connection->close("HTTP/1.1 413 Request Entity Too Large\r\n\r\n", true);
                 return 0;
             }
-        } elseif (\in_array($method, ['POST', 'PUT', 'PATCH'])) {
-            $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
-            return 0;
         }
 
         if (!isset($recv_buffer[512])) {

--- a/Protocols/Http.php
+++ b/Protocols/Http.php
@@ -125,6 +125,10 @@ class Http
             $has_content_length = true;
         } else {
             $has_content_length = false;
+            if (false !== stripos($header, "\r\nTransfer-Encoding:")) {
+                $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
+                return 0;
+            }
         }
 
         if ($has_content_length) {


### PR DESCRIPTION
RFC 允许不带上 `content-length` 请求头

https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2

![image](https://user-images.githubusercontent.com/20104656/191432797-2fd7f58d-418e-4f68-833b-e6f78e6fa637.png)

另外是否可以考虑增加自动化测试，比如 Github Actions，这样修改了东西可以跑一遍看看测试用例是否都通过，增加新功能、修复 bug 也可以增加测试用例。