### PR TITLE
Mandatory host header in http 1.1

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -103,7 +103,7 @@ class Http
         $header = \substr($recv_buffer, 0, $crlf_pos);
         $hostHeaderPosition = \strpos($header, "\r\nHost: ");
 
-        if (false === $hostHeaderPosition && $firstLine[2] !== "HTTP/1.1") {
+        if (false === $hostHeaderPosition && $firstLine[2] === "HTTP/1.1") {
             $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
             return 0;
         }


### PR DESCRIPTION
The host header is mandatory in every HTTP/1.1 requests. Currently workerman doesn't validate it's presence.

[https://www.rfc-editor.org/rfc/rfc2616#section-14.23](https://www.rfc-editor.org/rfc/rfc2616#section-14.23)