### PR TITLE
Http1.1 use by default persistent connections 

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -191,7 +191,7 @@ class Http
                 unset($connection->__header);
             }
             $body_len = \strlen((string)$response);
-            return "HTTP/1.1 200 OK\r\nServer: workerman\r\n{$ext_header}Connection: keep-alive\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\n\r\n$response";
+            return "HTTP/1.1 200 OK\r\nServer: workerman\r\n{$ext_header}Content-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\n\r\n$response";
         }
 
         if (isset($connection->__header)) {

--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -370,10 +370,6 @@ class Response
             $head .= "$name: $value\r\n";
         }
 
-        if (!isset($headers['Connection'])) {
-            $head .= "Connection: keep-alive\r\n";
-        }
-
         $file_info = \pathinfo($file);
         $extension = isset($file_info['extension']) ? $file_info['extension'] : '';
         $base_name = isset($file_info['basename']) ? $file_info['basename'] : 'unknown';
@@ -412,7 +408,7 @@ class Response
         $reason = $this->_reason ?: static::$_phrases[$this->_status] ?? '';
         $body_len = \strlen($this->_body);
         if (empty($this->_header)) {
-            return "HTTP/{$this->_version} {$this->_status} $reason\r\nServer: workerman\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\nConnection: keep-alive\r\n\r\n{$this->_body}";
+            return "HTTP/{$this->_version} {$this->_status} $reason\r\nServer: workerman\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $body_len\r\n\r\n{$this->_body}";
         }
 
         $head = "HTTP/{$this->_version} {$this->_status} $reason\r\n";
@@ -428,10 +424,6 @@ class Response
                 continue;
             }
             $head .= "$name: $value\r\n";
-        }
-
-        if (!isset($headers['Connection'])) {
-            $head .= "Connection: keep-alive\r\n";
         }
 
         if (!isset($headers['Content-Type'])) {


### PR DESCRIPTION
The keep-alive it's only for http1.0 and is very faulty.
We are sending **extra bytes in the response**,  that are ignored by the clients using http 1.1, 2 and 3. 

If you want, we can add it if they use http1.0. But I think they my decide it and add the header and nobody is using http1.0.

### Info:
https://serverfault.com/questions/790300/is-it-necessary-to-include-connection-keep-alive-in-the-response-message
https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1.1
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection
https://github.com/yhirose/cpp-httplib/issues/369#issuecomment-592719837

