### PR TITLE
Listen to http and websocket at the same worker

### DIFF
--- a/src/Protocols/HttpWebsocket.php
+++ b/src/Protocols/HttpWebsocket.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of workerman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Workerman\Protocols;
+
+use Workerman\Connection\TcpConnection;
+
+/**
+ * Http and Websocket Protocol.
+ */
+class HttpWebsocket
+{
+    /**
+     * Judge whether it is a Websocket protocol
+     *
+     * @param mixed $buffer 
+     * @param TcpConnection $connection 
+     * @return bool
+     */
+    static function isWebsocket($buffer, $connection): bool
+    {
+        if (isset($connection->context->isWebsocket)) {
+            return true;
+        }
+        if (substr($buffer, 0, 4) === "GET " && strpos($buffer, "\nUpgrade: websocket") !== false) {
+            $connection->context->isWebsocket = true;
+            $connection->context->websocketHandshakeBuffer = $buffer;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check the integrity of the package.
+     *
+     * @param string $buffer
+     * @param TcpConnection $connection
+     * @return int
+     */
+    public static function input($buffer, $connection)
+    {
+        $isWebsocket = self::isWebsocket($buffer, $connection);
+        if ($isWebsocket) {
+            return Websocket::input($buffer, $connection);
+        } else {
+            return Http::input($buffer, $connection);
+        }
+    }
+
+    /**
+     * Encode.
+     *
+     * @param string $buffer
+     * @param TcpConnection $connection
+     * @return string
+     */
+    public static function encode($buffer, $connection)
+    {
+        $isWebsocket = isset($connection->context->isWebsocket);
+        if ($isWebsocket) {
+            return Websocket::encode($buffer, $connection);
+        } else {
+            return Http::encode($buffer, $connection);
+        }
+    }
+
+    /**
+     * Decode.
+     *
+     * @param string $buffer
+     * @param TcpConnection $connection
+     * @return string
+     */
+    public static function decode($buffer, $connection)
+    {
+        $isWebsocket = isset($connection->context->isWebsocket);
+        if ($isWebsocket) {
+            $message = Websocket::decode($buffer, $connection);
+            return new \Workerman\Protocols\HttpWebsocket\Request($connection->context->websocketHandshakeBuffer, $message);
+        } else {
+            return Http::decode($buffer, $connection);
+        }
+    }
+}

--- a/src/Protocols/HttpWebsocket/Request.php
+++ b/src/Protocols/HttpWebsocket/Request.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of workerman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Workerman\Protocols\HttpWebsocket;
+
+/**
+ * Class Request
+ * @package Workerman\Protocols\HttpWebsocket
+ */
+class Request extends \Workerman\Protocols\Http\Request
+{
+
+    /**
+     * Received message content
+     *
+     * @var array
+     */
+    protected $_message;
+
+
+    /**
+     * Request constructor.
+     *
+     * @param string $buffer
+     * @param string $message
+     */
+    public function __construct($buffer, $message)
+    {
+        $this->_buffer = $buffer;
+        $this->_message = $message;
+    }
+
+    /**
+     * Get received message content.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return $this->_message;
+    }
+}

--- a/src/Protocols/HttpWebsocket/Request.php
+++ b/src/Protocols/HttpWebsocket/Request.php
@@ -16,7 +16,7 @@
 namespace Workerman\Protocols\HttpWebsocket;
 
 /**
- * Class Request
+ * Websocket Request
  * @package Workerman\Protocols\HttpWebsocket
  */
 class Request extends \Workerman\Protocols\Http\Request
@@ -25,10 +25,9 @@ class Request extends \Workerman\Protocols\Http\Request
     /**
      * Received message content
      *
-     * @var array
+     * @var string
      */
     protected $_message;
-
 
     /**
      * Request constructor.


### PR DESCRIPTION
在同一个端口号处理Http和Websocket服务，需在onMessage中判断$request是Http\Request还是\HttpWebsocket\Request
```php

use Workerman\Connection\TcpConnection;
use Workerman\Protocols\Http\Request;
use Workerman\Worker;

$worker = new Worker("HttpWebsocket://0.0.0.0:886");
$worker->onMessage = function (TcpConnection $tcpConnection, Request $request) {
    if ($request instanceof \Workerman\Protocols\HttpWebsocket\Request) {
        $path = $request->path();
        $message = $request->message();
        $tcpConnection->send("[path] $path\n[message] $message");
    } else {
        $tcpConnection->send('
            <script>
                var ws = new WebSocket("ws://" + location.host + "/api" );
                ws.onmessage = function(event) {
                    alert(event.data);
                };
                ws.onopen = function() {
                    ws.send("hello world");
                };
            </script>
        ');
    }
};
Worker::runAll();
```