### PR TITLE
Unconvert first letter to lowercase `Worker::getSocketName()` 

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2348,7 +2348,7 @@ class Worker
      */
     public function getSocketName()
     {
-        return $this->_socketName ? \lcfirst($this->_socketName) : 'none';
+        return $this->_socketName ? $this->_socketName : 'none';
     }
 
     /**


### PR DESCRIPTION
SocketName no need to convert lower case.
It's totally unnecessary.

