### PR TITLE
support worker:$protocolRoot for custom protocols 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 logs
+vendor
+composer.lock
 .buildpath
 .project
 .settings

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -308,6 +308,13 @@ class Worker
     public static $processTitle = 'WorkerMan';
 
     /**
+     * Custom Protocols Root Namespace
+     *
+     * @var string
+     */
+    public static $protocolRoot = 'Protocols\\';
+
+    /**
      * After sending the stop command to the child process stopTimeout seconds,
      * if the process is still living then forced to kill.
      *
@@ -2290,11 +2297,11 @@ class Worker
         // Check application layer protocol class.
         if (!isset(self::BUILD_IN_TRANSPORTS[$scheme])) {
             $scheme         = \ucfirst($scheme);
-            $this->protocol = \substr($scheme,0,1)==='\\' ? $scheme : 'Protocols\\' . $scheme;
+            $this->protocol = \substr($scheme,0,1)==='\\' ? $scheme : self::$protocolRoot . $scheme;
             if (!\class_exists($this->protocol)) {
                 $this->protocol = "Workerman\\Protocols\\$scheme";
                 if (!\class_exists($this->protocol)) {
-                    throw new Exception("class \\Protocols\\$scheme not exist");
+                    throw new Exception("protocol $scheme not exist");
                 }
             }
 


### PR DESCRIPTION
Usage:
    Worker::$protocolRoot = 'MyProject\\Services\\Lib\\Protocols\\';

    $worker = new Worker("custom://host:1234");
