### PR TITLE
Separate app error message from process terminated

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -2063,7 +2063,7 @@ class Worker
     public static function checkErrors()
     {
         if (static::STATUS_SHUTDOWN !== static::$_status) {
-            $error_msg = static::$_OS === \OS_TYPE_LINUX ? 'Worker['. \posix_getpid() .'] process terminated' : 'Worker process terminated';
+            $error_msg = static::$_OS === \OS_TYPE_LINUX ? ' |> Worker['. \posix_getpid() .'] process terminated' : 'Worker process terminated';
             $errors    = error_get_last();
             if ($errors && ($errors['type'] === \E_ERROR ||
                     $errors['type'] === \E_PARSE ||


### PR DESCRIPTION
To prevent confusions, with the message.

Example:
![image](https://user-images.githubusercontent.com/249085/208655007-6c86d574-0294-4149-a58a-74b9242003d6.png)


Looks like the error is that is missing, the Config FileWorker.