### PR TITLE
Fix connection closed before file send completed

### DIFF
--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -723,6 +723,9 @@ class TcpConnection extends ConnectionInterface implements \JsonSerializable
                 }
             }
             if ($this->_status === self::STATUS_CLOSING) {
+                if ($this->__streamSending) {
+                    return true;
+                }
                 $this->destroy();
             }
             return true;

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -249,6 +249,7 @@ class Http
     protected static function sendStream(TcpConnection $connection, $handler, $offset = 0, $length = 0)
     {
         $connection->bufferFull = false;
+        $connection->__streamSending = true;
         if ($offset !== 0) {
             \fseek($handler, $offset);
         }
@@ -275,6 +276,7 @@ class Http
                 if ($buffer === '' || $buffer === false) {
                     fclose($handler);
                     $connection->onBufferDrain = null;
+                    $connection->__streamSending = false;
                     return;
                 }
                 $connection->send($buffer, true);


### PR DESCRIPTION
 When use $connection->close() to send a big file (size larger than 2M),  connection may be closed before file is sent.