### PR TITLE
Fixed a bug where file types were overwritten

### DIFF
--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -606,13 +606,13 @@ class Request
                         }
                         $uploadKey = $fileName;
                         // Parse upload files.
-                        $file = [
+                        $file = array_merge($file, [
                             'name' => $match[2],
                             'tmp_name' => $tmpFile,
                             'size' => $size,
-                            'error' => $error,
-                            'type' => '',
-                        ];
+                            'error' => $error
+                        ]);
+                        if (!isset($file['type'])) $file['type'] = '';
                         break;
                     } // Is post field.
                     else {


### PR DESCRIPTION
Content-Type: image/jpeg
Content-Transfer-Encoding: 8bit
Content-Disposition: form-data; name="file"; filename="11.jpg"

In this case, the file type is overwritten and cannot be retrieved