### PR TITLE
Fix ext headers

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -212,10 +212,10 @@ class Http
                 foreach ($connection->headers as $name => $value) {
                     if (is_array($value)) {
                         foreach ($value as $item) {
-                            $extHeader = "$name: $item\r\n";
+                            $extHeader .= "$name: $item\r\n";
                         }
                     } else {
-                        $extHeader = "$name: $value\r\n";
+                        $extHeader .= "$name: $value\r\n";
                     }
                 }
                 $connection->headers = [];


### PR DESCRIPTION
During writing tests for `Http` I found the extension headers are not handled correctly for non-object response. Only the last one will be applied. This PR fixes this issue.
