### PR TITLE
behavior tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - feature/tests
+      - feature/feature-tests
   pull_request:
   schedule:
     - cron: '0 0 * * *'
@@ -29,7 +30,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: json
+          extensions: json, posix, pcntl
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: xdebug

--- a/tests/Feature/UdpConnectionTest.php
+++ b/tests/Feature/UdpConnectionTest.php
@@ -1,31 +1,46 @@
 <?php
-//example from manual
-use Workerman\Connection\AsyncUdpConnection;
-use Workerman\Timer;
+
+use Symfony\Component\Process\PhpProcess;
 use Workerman\Worker;
 
-it('tests udp connection', function () {
-    /** @noinspection PhpObjectFieldsAreOnlyWrittenInspection */
-    $server = new Worker('udp://0.0.0.0:9292');
-    $server->onMessage = function ($connection, $data) {
-        expect($data)->toBe('hello');
-        $connection->send('xiami');
-    };
-    $server->onWorkerStart = function () {
-        //client
-        Timer::add(1, function () {
-            $client = new AsyncUdpConnection('udp://127.0.0.1:1234');
-            $client->onConnect = function ($client) {
-                $client->send('hello');
-            };
-            $client->onMessage = function ($client, $data) {
-                expect($data)->toBe('xiami');
-                //terminal this test
-                terminate_current_test();
-            };
-            $client->connect();
-        }, null, false);
-    };
-    Worker::runAll();
-})->skipOnWindows() //require posix, multiple workers
-->skip(message: 'this test needs to run isolated process while pest not support doing so yet');
+$serverAddress = 'udp://127.0.0.1:6789';
+beforeAll(function () use ($serverAddress) {
+    $process = new PhpProcess(<<<PHP
+        <?php    
+        if(!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
+        if(!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
+        if(!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
+        require './vendor/autoload.php';
+        use Workerman\Worker;
+        
+        \$server = new Worker('$serverAddress');
+        \$server->onMessage = function (\$connection, \$data) {
+            if(str_starts_with(\$data, 'bye')) {
+                terminate_current_process();
+            }
+            \$connection->send('received: '.\$data);
+        };
+        global \$argv;
+        \$argv = ['', 'start'];
+        Worker::runAll();
+    PHP
+    );
+    $process->start();
+    sleep(5);
+});
+
+afterAll(function () use ($serverAddress) {
+    $socket = stream_socket_client(self::$serverAddress, timeout: 1);
+    fwrite($socket, 'bye');
+    fclose($socket);
+});
+
+it('tests udp connection', function () use ($serverAddress) {
+    $socket = stream_socket_client($serverAddress, $errno, $errstr, 1);
+    expect($errno)->toBeInt(0);
+    fwrite($socket, 'xiami');
+    $data = fread($socket, 1024);
+    expect($data)->toBeString('received: xiami');
+    fclose($socket);
+})
+    ->skipOnWindows(); //require posix

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -59,7 +59,7 @@ function testWithConnectionClose(Closure $closure, string $dataContains = null, 
     }
 }
 
-function terminate_current_test()
+function terminate_current_process()
 {
     posix_kill(posix_getppid(), SIGINT);
 }


### PR DESCRIPTION
TL;DR 
This is a working example of behavior test. Consider workerman as a black box server and verify tests as clients.

As discussed in #904 , I mentioned the behavior test is not doable because pest lacks supporting for isolation process tests. However, after experiments with PhpUnit, I realized [@runinseparateprocess](https://docs.phpunit.de/en/10.0/annotations.html#runinseparateprocess) doesn't help as well. The only programming way to kill the service itself from inside is to kill the whole process, but even for PhpUnit it still requires to do certain jobs after the test method(s). Killing the proces is considered as an error and will leads to a test failure.

This PR proposed a different way for such tests. Instead of trying to asset values on both side, we consider the server side as a black box and only pay attention to the value we sent and received as a client.  To archive this, we create a new process during `beforeAll`/`setUp` (with the help of symfony's `PhpProcess`) and stop it during `afterAll`/`tearDown`. Thus all tests in same file/class can communicate with the server and checking the server's behavior.

---

p.s. a not-so-small suggestion. Tests are not just about adding more test cases. Workerman also needs to be changed/modified to enable better and more comprehensive tests. e.g. When I tried to start workerman, the only way I found is to override `$argv`. There is a `static::$command` and `getArgv` in `Worker` so I guess the author does have an intention to support such use case. However, `parseCommand` still only use `$argv` as the only input, which make `$command` much less useful.
