### PR TITLE
Improve file uploads

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -319,6 +319,18 @@ class Http
         $doWrite();
     }
 
+    public static function onClose(TcpConnection $connection): void
+    {
+        $globalUploadedFiles = Request::getGlobalUploadedFiles();
+        if(!empty($globalUploadedFiles)){
+            foreach ($globalUploadedFiles as $file){
+                if(is_file($file)){
+                    unlink($file);
+                }
+            }
+        }
+    }
+
     /**
      * Set or get uploadTmpDir.
      *

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -322,13 +322,15 @@ class Http
     public static function onClose(TcpConnection $connection): void
     {
         $globalUploadedFiles = Request::getGlobalUploadedFiles();
-        if(!empty($globalUploadedFiles)){
-            foreach ($globalUploadedFiles as $file){
-                if(is_file($file)){
+        if (!empty($globalUploadedFiles)) {
+            foreach ($globalUploadedFiles as $file) {
+                if (is_file($file)) {
                     unlink($file);
                 }
             }
         }
+
+        $connection->request?->session?->gc();
     }
 
     /**

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -652,6 +652,8 @@ class Request
                             if ($tmpFile === false || false === file_put_contents($tmpFile, $boundaryValue)) {
                                 $error = UPLOAD_ERR_CANT_WRITE;
                             }
+                            $this->uploadedFiles[] = $tmpFile;
+                            self::$globalUploadedFiles[] = $tmpFile;
                         }
                         $uploadKey = $fileName;
                         // Parse upload files.

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -152,7 +152,19 @@ class Request
                 if (!in_array($from, Request::$globalUploadedFiles, true)) {
                     return false;
                 }
-                return rename($from, $to);
+                $successful = false;
+                if (rename($from, $to)) {
+                    $successful = true;
+                } elseif (copy($from, $to)) {
+                    unlink($from);
+                    $successful = true;
+                }
+                if($successful) {
+                    Request::$globalUploadedFiles = array_diff(Request::$globalUploadedFiles, [$from]);
+                }else{
+                    trigger_error(sprintf('Unable to move "%s" to "%s"', $from, $to), E_USER_WARNING);
+                }
+                return $successful;
             }
         }
     }

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -681,13 +681,11 @@ class Request
                         }
                         $uploadKey = $fileName;
                         // Parse upload files.
-                        $file = array_merge($file, [
-                            'name' => $match[2],
-                            'tmp_name' => $tmpFile,
-                            'size' => $size,
-                            'error' => $error
-                        ]);
-                        if (!isset($file['type'])) $file['type'] = '';
+                        $file['name'] = $match[2];
+                        $file['tmp_name'] = $tmpFile;
+                        $file['size'] = $size;
+                        $file['error'] = $error;
+                        $file['type'] ??= '';
                         break;
                     } // Is post field.
                     else {

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -731,6 +731,11 @@ class Request
             . (!$cookieParams['httponly'] ? '' : '; HttpOnly')];
     }
 
+    public static function getGlobalUploadedFiles(): array
+    {
+        return self::$globalUploadedFiles;
+    }
+
     /**
      * __toString.
      */
@@ -791,15 +796,15 @@ class Request
      */
     public function __destruct()
     {
-        if (isset($this->data['files'])) {
+        if (!empty($this->uploadedFiles)) {
             clearstatcache();
-            array_walk_recursive($this->data['files'], function ($value, $key) {
-                if ($key === 'tmp_name') {
-                    if (is_file($value)) {
-                        unlink($value);
-                    }
+            foreach ($this->uploadedFiles as $file) {
+                if (is_file($file)) {
+                    unlink($file);
                 }
-            });
+            }
+            self::$globalUploadedFiles = array_diff(self::$globalUploadedFiles, $this->uploadedFiles);
+            $this->uploadedFiles = [];
         }
     }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -637,6 +637,9 @@ class Worker
 
         // Timer init.
         Timer::init();
+
+        // init HTTP Request
+        \Workerman\Protocols\Http\Request::init();
     }
 
     /**


### PR DESCRIPTION
This PR includes following improvements:
1.	Respect `max_file_uploads` from `php.ini` if available
2.	Override `is_uploaded_file` and `move_uploaded_file` when possible, with a workerman compatible implementations
3.	Respect `upload_max_filesize` from `php.ini` since PHP 8.2 
4.	Clean up uploaded temporary files for exceptional cases
5.	Clean up session for exceptional cases

## More details about overriding `is_uploaded_file` and `move_uploaded_file`

Since PHP 8.0, if a built-in function is disabled by `disable_functions`, it's possible to implement them in userland. As the master branch requires PHP 8.1, I think it's a good time to introduce this change.

## Cleaning for exceptional cases

I understand that there is cleaning for uploaded files during desturction. However, this is based on `$_FILES`. There is chance that a temporary file is creatd but not loaded into `$_FILES`. 
Besides, this PR also includes a fallback cleanup for uploaded files and sessions.