### PR TITLE
Fix the SSE response data format

### DIFF
--- a/src/Protocols/Http/ServerSentEvents.php
+++ b/src/Protocols/Http/ServerSentEvents.php
@@ -55,15 +55,15 @@ class ServerSentEvents
         if (isset($data['event'])) {
             $buffer .= "event: {$data['event']}\n";
         }
-        if (isset($data['data'])) {
-            $buffer .= 'data: ' . str_replace("\n", "\ndata: ", $data['data']) . "\n\n";
-        }
         if (isset($data['id'])) {
             $buffer .= "id: {$data['id']}\n";
         }
         if (isset($data['retry'])) {
             $buffer .= "retry: {$data['retry']}\n";
         }
-        return $buffer;
+        if (isset($data['data'])) {
+            $buffer .= 'data: ' . str_replace("\n", "\ndata: ", $data['data']) . "\n";
+        }
+        return $buffer . "\n";
     }
 }

--- a/tests/Unit/Protocols/Http/ServerSentEventsTest.php
+++ b/tests/Unit/Protocols/Http/ServerSentEventsTest.php
@@ -10,6 +10,6 @@ it('tests ' . ServerSentEvents::class, function () {
         'retry' => 5000,
     ];
     $sse = new ServerSentEvents($data);
-    $expected = "event: {$data['event']}\ndata: {$data['data']}\n\nid: {$data['id']}\nretry: {$data['retry']}\n";
+    $expected = "event: {$data['event']}\nid: {$data['id']}\nretry: {$data['retry']}\ndata: {$data['data']}\n\n";
     expect((string)$sse)->toBe($expected);
 });


### PR DESCRIPTION
只在 `data:` 后加 `\n\n` 是不对