### PR TITLE
Fixed typos, removed PHPStorm attributes and change DEBUG to USER

### DIFF
--- a/src/Connection/AsyncTcpConnection.php
+++ b/src/Connection/AsyncTcpConnection.php
@@ -301,7 +301,7 @@ class AsyncTcpConnection extends TcpConnection
             }
             return;
         }
-        // Add socket to global event loop waiting connection is successfully established or faild.
+        // Add socket to global event loop waiting connection is successfully established or failed.
         $this->eventLoop->onWritable($this->socket, [$this, 'checkConnection']);
         // For windows.
         if (DIRECTORY_SEPARATOR === '\\' && method_exists($this->eventLoop, 'onExcept')) {

--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -1036,7 +1036,7 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
      * @param mixed $value
      */
     public static function enableCache(bool $value = true): void
-	{
+    {
         static::$enableCache = $value;
     }
 
@@ -1062,12 +1062,12 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
         ];
     }
 
-	/**
-	 * Destruct.
-	 *
-	 * @return void
-	 * @throws Throwable
-	 */
+    /**
+     * Destruct.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public function __destruct()
     {
         static $mod;

--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace Workerman\Connection;
 
-use JetBrains\PhpStorm\Pure;
 use JsonSerializable;
 use stdClass;
 use Throwable;
@@ -898,7 +897,6 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
      *
      * return bool.
      */
-    #[Pure]
     public function isIpV4(): bool
     {
         if ($this->transport === 'unix') {
@@ -912,7 +910,6 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
      *
      * return bool.
      */
-    #[Pure]
     public function isIpV6(): bool
     {
         if ($this->transport === 'unix') {
@@ -1038,8 +1035,8 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
      *
      * @param mixed $value
      */
-    public static function enableCache(bool $value = true)
-    {
+    public static function enableCache(bool $value = true): void
+	{
         static::$enableCache = $value;
     }
 
@@ -1065,11 +1062,12 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
         ];
     }
 
-    /**
-     * Destruct.
-     *
-     * @return void
-     */
+	/**
+	 * Destruct.
+	 *
+	 * @return void
+	 * @throws Throwable
+	 */
     public function __destruct()
     {
         static $mod;

--- a/src/Connection/UdpConnection.php
+++ b/src/Connection/UdpConnection.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
 
 namespace Workerman\Connection;
 
-use JetBrains\PhpStorm\ArrayShape;
-use JetBrains\PhpStorm\Pure;
 use JsonSerializable;
 use Workerman\Protocols\ProtocolInterface;
 use function stream_socket_get_name;
@@ -191,7 +189,6 @@ class UdpConnection extends ConnectionInterface implements JsonSerializable
      *
      * return bool.
      */
-    #[Pure]
     public function isIpV4(): bool
     {
         if ($this->transport === 'unix') {
@@ -205,7 +202,6 @@ class UdpConnection extends ConnectionInterface implements JsonSerializable
      *
      * return bool.
      */
-    #[Pure]
     public function isIpV6(): bool
     {
         if ($this->transport === 'unix') {
@@ -229,10 +225,6 @@ class UdpConnection extends ConnectionInterface implements JsonSerializable
      *
      * @return array
      */
-    #[ArrayShape([
-        'transport' => "string", 'getRemoteIp' => "string", 'remotePort' => "int", 'getRemoteAddress' => "string",
-        'getLocalIp' => "string", 'getLocalPort' => "int", 'getLocalAddress' => "string", 'isIpV4' => "bool", 'isIpV6' => "bool"]
-    )]
     public function jsonSerialize(): array
     {
         return [

--- a/src/Events/Select.php
+++ b/src/Events/Select.php
@@ -380,7 +380,7 @@ class Select implements EventInterface
             if ($read || $write || $except) {
                 // Waiting read/write/signal/timeout events.
                 try {
-                    @stream_select($read, $write, $except, 0, $this->selectTimeout);
+                    stream_select($read, $write, $except, 0, $this->selectTimeout);
                 } catch (Throwable) {
                 }
             } else {

--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -236,14 +236,14 @@ class Websocket
         return 0;
     }
 
-    /**
-     * Websocket encode.
-     *
-     * @param mixed $buffer
-     * @param TcpConnection $connection
-     * @return string
-     * @throws Exception
-     */
+	/**
+	 * Websocket encode.
+	 *
+	 * @param mixed $buffer
+	 * @param TcpConnection $connection
+	 * @return string
+	 * @throws Throwable
+	 */
     public static function encode(mixed $buffer, TcpConnection $connection): string
     {
         if (!is_scalar($buffer)) {

--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -236,14 +236,14 @@ class Websocket
         return 0;
     }
 
-	/**
-	 * Websocket encode.
-	 *
-	 * @param mixed $buffer
-	 * @param TcpConnection $connection
-	 * @return string
-	 * @throws Throwable
-	 */
+    /**
+     * Websocket encode.
+     *
+     * @param mixed $buffer
+     * @param TcpConnection $connection
+     * @return string
+     * @throws Throwable
+     */
     public static function encode(mixed $buffer, TcpConnection $connection): string
     {
         if (!is_scalar($buffer)) {
@@ -362,7 +362,7 @@ class Websocket
                 $SecWebSocketKey = $match[1];
             } else {
                 $connection->close(
-					"HTTP/1.0 200 OK\r\nServer: workerman\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1><hr>workerman</div>", true);
+                    "HTTP/1.0 200 OK\r\nServer: workerman\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1><hr>workerman</div>", true);
                 return 0;
             }
             // Calculation websocket key.

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -828,10 +828,10 @@ class Worker
         if (static::$daemonize) {
             static::safeEcho('Input "php ' . basename(static::$startFile) . ' stop" to stop. Start success.' . "\n\n");
         } else if (!empty(static::$command)) {
-			static::safeEcho("Start success.\n"); // Workerman used as library
+            static::safeEcho("Start success.\n"); // Workerman used as library
         } else {
-			static::safeEcho("Press Ctrl+C to stop. Start success.\n");
-		}
+            static::safeEcho("Press Ctrl+C to stop. Start success.\n");
+        }
     }
 
     /**
@@ -1167,12 +1167,12 @@ class Worker
         }
     }
 
-	/**
-	 * Signal handler.
-	 *
-	 * @param int $signal
-	 * @throws Throwable
-	 */
+    /**
+     * Signal handler.
+     *
+     * @param int $signal
+     * @throws Throwable
+     */
     public static function signalHandler(int $signal): void
     {
         switch ($signal) {
@@ -1300,9 +1300,9 @@ class Worker
         }
 
         static::$masterPid = posix_getpid();
-		if (false === file_put_contents(static::$pidFile, static::$masterPid)) {
-			throw new RuntimeException('can not save pid to ' . static::$pidFile);
-		}
+        if (false === file_put_contents(static::$pidFile, static::$masterPid)) {
+            throw new RuntimeException('can not save pid to ' . static::$pidFile);
+        }
     }
 
     /**
@@ -1786,12 +1786,12 @@ class Worker
         exit(0);
     }
 
-	/**
-	 * Execute reload.
-	 *
-	 * @return void
-	 * @throws Throwable
-	 */
+    /**
+     * Execute reload.
+     *
+     * @return void
+     * @throws Throwable
+     */
     protected static function reload(): void
     {
         // For master process.
@@ -1868,13 +1868,13 @@ class Worker
         }
     }
 
-	/**
-	 * Stop all.
-	 *
-	 * @param int $code
-	 * @param mixed $log
-	 * @throws Throwable
-	 */
+    /**
+     * Stop all.
+     *
+     * @param int $code
+     * @param mixed $log
+     * @throws Throwable
+     */
     public static function stopAll(int $code = 0, mixed $log = ''): void
     {
         if ($log) {
@@ -2451,12 +2451,12 @@ class Worker
         }
     }
 
-	/**
-	 * Stop current worker instance.
-	 *
-	 * @return void
-	 * @throws Throwable
-	 */
+    /**
+     * Stop current worker instance.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public function stop(): void
     {
         // Try to emit onWorkerStop callback.
@@ -2485,13 +2485,13 @@ class Worker
         $this->onMessage = $this->onClose = $this->onError = $this->onBufferDrain = $this->onBufferFull = null;
     }
 
-	/**
-	 * Accept a connection.
-	 *
-	 * @param resource $socket
-	 * @return void
-	 * @throws Throwable
-	 */
+    /**
+     * Accept a connection.
+     *
+     * @param resource $socket
+     * @return void
+     * @throws Throwable
+     */
     public function acceptTcpConnection($socket): void
     {
         // Accept a connection on server socket.
@@ -2527,13 +2527,13 @@ class Worker
         }
     }
 
-	/**
-	 * For udp package.
-	 *
-	 * @param resource $socket
-	 * @return bool
-	 * @throws Throwable
-	 */
+    /**
+     * For udp package.
+     *
+     * @param resource $socket
+     * @return bool
+     * @throws Throwable
+     */
     public function acceptUdpConnection($socket): bool
     {
         set_error_handler(function () {


### PR DESCRIPTION
Changed log file permissions to `0644`, otherwise it cannot be deleted by user belonging to the same group.
Added extra if statement when Process start for library mode without the `Control+C` statement.
Renamed DEBUG mode to USER mode. When using Workerman as library with `Worker::$command`, log contains DEBUG mode and cannot be presented to client.