### PR TITLE
🐛 import function `waitAll`

### DIFF
--- a/src/Events/Swow.php
+++ b/src/Events/Swow.php
@@ -9,6 +9,7 @@ use Swow\Coroutine;
 use Swow\Signal;
 use Swow\SignalException;
 use Throwable;
+use function Swow\Sync\waitAll;
 
 class Swow implements EventInterface
 {


### PR DESCRIPTION
你好，发现在你之前移除 import function 的修改中错误删除了waitAll的引入，另外还有以下疑问
- 需要移除 import function 的原因是什么，别的包可能有跟全局函数同名冲突
- 希望可以引入标准工具增强项目代码质量，如`cs-fixer`,`phpstan`等