### PR TITLE
Fix 400 Bad Request

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -118,7 +118,7 @@ class Http
         $firstLine = explode(" ", strstr($buffer, "\r\n", true), 3);
 
         if (!in_array($firstLine[0], ['GET', 'POST', 'OPTIONS', 'HEAD', 'DELETE', 'PUT', 'PATCH'])) {
-            $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
+            $connection->close("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n", true);
             return 0;
         }
 
@@ -126,7 +126,7 @@ class Http
         $hostHeaderPosition = stripos($header, "\r\nHost: ");
 
         if (false === $hostHeaderPosition && $firstLine[2] === "HTTP/1.1") {
-            $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
+            $connection->close("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n", true);
             return 0;
         }
 
@@ -139,7 +139,7 @@ class Http
         } else {
             $hasContentLength = false;
             if (false !== stripos($header, "\r\nTransfer-Encoding:")) {
-                $connection->close("HTTP/1.1 400 Bad Request\r\n\r\n", true);
+                $connection->close("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n", true);
                 return 0;
             }
         }


### PR DESCRIPTION
I found the problem with the Feature Tests in Adapterman.

The test stop, and never finish, when testing a bad request.
The problem is that the client is waiting for the body or close.

Testing direct with curl:
![image](https://github.com/walkor/workerman/assets/249085/7a9da6ce-2bec-4d76-b198-95ec8fc974f2)
and wait here, till I press Ctrl+c

Now:
![image](https://github.com/walkor/workerman/assets/249085/a977212b-b608-4d20-9979-9d05d67ede1b)


The curios thing is that the `400 Bad Request` is _Unit tested_ in this repo without problems.
For that we need more Feature Tests.

All the Adapterman Feature Tests work with Workerman.
When they are more polished, I'll create a PR to add it to Workerman.

Update: perhaps will be better to close the connection, like you want.