### PR TITLE
Add PHP 8.3 nightly to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
+        php: ["8.1", "8.2", "8.3"]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,5 @@ jobs:
 #          command: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/pest --coverage
+        run: vendor/bin/pest --coverage --colors=always
 


### PR DESCRIPTION
Testing with PHP 8.3 nightly, we can find problems in advance. 
And add color to Pest tests.