### PR TITLE
Disable fail-fast in GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: ["8.1", "8.2", "8.3"]
         stability: [prefer-lowest, prefer-stable]


### PR DESCRIPTION
To run all tests, perhaps only fail with one php version.
