### PR TITLE
Add $_FILES['full_path']

### DIFF
--- a/src/Events/EventInterface.php
+++ b/src/Events/EventInterface.php
@@ -21,7 +21,7 @@ interface EventInterface
      * Delay the execution of a callback.
      * @param float $delay
      * @param callable $func
-     * @param array $args
+     * @param mixed[] $args
      * @return int
      */
     public function delay(float $delay, callable $func, array $args = []): int;
@@ -37,7 +37,7 @@ interface EventInterface
      * Repeatedly execute a callback.
      * @param float $interval
      * @param callable $func
-     * @param array $args
+     * @param mixed[] $args
      * @return int
      */
     public function repeat(float $interval, callable $func, array $args = []): int;

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -632,7 +632,7 @@ class Request
                     $file['type'] = trim($value);
                     break;
 
-                case "webkitRelativePath":
+                case "webkitrelativepath":
                     $file['full_path'] = \trim($value);
                     break;
             }

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -593,6 +593,7 @@ class Request
             }
             [$key, $value] = explode(': ', $contentLine);
             switch (strtolower($key)) {
+
                 case "content-disposition":
                     // Is file data.
                     if (preg_match('/name="(.*?)"; filename="(.*?)"/i', $value, $match)) {
@@ -613,7 +614,7 @@ class Request
                         }
                         $uploadKey = $fileName;
                         // Parse upload files.
-                        $file = [...$file, 'name' => $match[2], 'tmp_name' => $tmpFile, 'size' => $size, 'error' => $error];
+                        $file = [...$file, 'name' => $match[2], 'tmp_name' => $tmpFile, 'size' => $size, 'error' => $error, 'full_path' => $match[2]];
                         if (!isset($file['type'])) {
                             $file['type'] = '';
                         }
@@ -626,8 +627,13 @@ class Request
                         $postEncodeString .= urlencode($k) . "=" . urlencode($boundaryValue) . '&';
                     }
                     return $sectionEndOffset + strlen($boundary) + 2;
+                
                 case "content-type":
                     $file['type'] = trim($value);
+                    break;
+
+                case "webkitRelativePath":
+                    $file['full_path'] = \trim($value);
                     break;
             }
         }


### PR DESCRIPTION
PHP 8.1: $_FILES: New full_path value for directory-uploads

https://php.watch/versions/8.1/$_FILES-full-path

If don't exist `webkitRelativePath`, the value is the file name only.