### PR TITLE
Type union instead of mixed

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -217,6 +217,7 @@ class Http
                 }
                 $connection->headers = [];
             }
+            $response = (string)$response;
             $bodyLen = strlen($response);
             return "HTTP/1.1 200 OK\r\nServer: workerman\r\n{$extHeader}Connection: keep-alive\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $bodyLen\r\n\r\n$response";
         }

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -86,7 +86,7 @@ class Http
      *
      * @param bool $value
      */
-    public static function enableCache(bool $value)
+    public static function enableCache(bool $value): void
     {
         static::$enableCache = $value;
     }
@@ -197,7 +197,7 @@ class Http
      * @return string
      * @throws Throwable
      */
-    public static function encode(mixed $response, TcpConnection $connection): string
+    public static function encode(string|Response $response, TcpConnection $connection): string
     {
         if (isset($connection->request)) {
             $request = $connection->request;
@@ -217,7 +217,6 @@ class Http
                 }
                 $connection->headers = [];
             }
-            $response = (string)$response;
             $bodyLen = strlen($response);
             return "HTTP/1.1 200 OK\r\nServer: workerman\r\n{$extHeader}Connection: keep-alive\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: $bodyLen\r\n\r\n$response";
         }

--- a/src/Protocols/Http/Chunk.php
+++ b/src/Protocols/Http/Chunk.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Workerman\Protocols\Http;
 
+use Stringable;
+
 use function dechex;
 use function strlen;
 
@@ -23,7 +25,7 @@ use function strlen;
  * Class Chunk
  * @package Workerman\Protocols\Http
  */
-class Chunk
+class Chunk implements Stringable
 {
     /**
      * Chunk buffer.
@@ -47,7 +49,7 @@ class Chunk
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return dechex(strlen($this->buffer)) . "\r\n$this->buffer\r\n";
     }

--- a/src/Protocols/Http/Request.php
+++ b/src/Protocols/Http/Request.php
@@ -18,6 +18,7 @@ namespace Workerman\Protocols\Http;
 
 use Exception;
 use RuntimeException;
+use Stringable;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http;
 use function array_walk_recursive;
@@ -49,7 +50,7 @@ use function urlencode;
  * Class Request
  * @package Workerman\Protocols\Http
  */
-class Request
+class Request implements Stringable
 {
     /**
      * Connection.
@@ -680,7 +681,7 @@ class Request
     /**
      * __toString.
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->buffer;
     }

--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Workerman\Protocols\Http;
 
+use Stringable;
+
 use function array_merge_recursive;
 use function explode;
 use function file;
@@ -35,7 +37,7 @@ use const FILE_SKIP_EMPTY_LINES;
  * Class Response
  * @package Workerman\Protocols\Http
  */
-class Response
+class Response implements Stringable
 {
     /**
      * Header data.
@@ -426,7 +428,7 @@ class Response
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->file) {
             return $this->createHeadForFile($this->file);

--- a/src/Protocols/Http/ServerSentEvents.php
+++ b/src/Protocols/Http/ServerSentEvents.php
@@ -16,13 +16,15 @@ declare(strict_types=1);
 
 namespace Workerman\Protocols\Http;
 
+use Stringable;
+
 use function str_replace;
 
 /**
  * Class ServerSentEvents
  * @package Workerman\Protocols\Http
  */
-class ServerSentEvents
+class ServerSentEvents implements Stringable
 {
     /**
      * Data.
@@ -45,7 +47,7 @@ class ServerSentEvents
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $buffer = '';
         $data = $this->data;

--- a/tests/Feature/HttpConnectionTest.php
+++ b/tests/Feature/HttpConnectionTest.php
@@ -11,10 +11,10 @@ beforeAll(function () use (&$process) {
     $process = new PhpProcess($code);
     $process->start();
     sleep(1);
-    $process->getOutput();
 });
 
 afterAll(function () use (&$process) {
+    $process->getOutput();
     $process->stop();
 });
 

--- a/tests/Feature/HttpConnectionTest.php
+++ b/tests/Feature/HttpConnectionTest.php
@@ -11,6 +11,7 @@ beforeAll(function () use (&$process) {
     $process = new PhpProcess($code);
     $process->start();
     sleep(1);
+    $process->getOutput();
 });
 
 afterAll(function () use (&$process) {

--- a/tests/Feature/HttpConnectionTest.php
+++ b/tests/Feature/HttpConnectionTest.php
@@ -14,7 +14,7 @@ beforeAll(function () use (&$process) {
 });
 
 afterAll(function () use (&$process) {
-    $process->getOutput();
+    echo $process->getOutput();
     $process->stop();
 });
 


### PR DESCRIPTION
Update: investigating why the `/session` test fail !!

Update: the `Session->pull()` return mixed, thinking about what will happen if return an `array`, the `encode()` will not show it corretly.

I think that need to be forced to `string|Response`  or `string|Stringable` the `encode()`, `send()` and `close()` methods and perhaps in TcpConnection too. :thinking: 
Check https://3v4l.org/Og7d6
Also we need to catch the error and send a 500, now only stop and send nothing.

@walkor what do you think ?