### PR TITLE
Add Windows and Mac Os to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   linux_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,3 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/pest --coverage --colors=always
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         php: ["8.1", "8.2", "8.3"]
         stability: [prefer-lowest, prefer-stable]
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} 
 
     steps:
       - name: Checkout code

--- a/tests/Feature/UdpConnectionTest.php
+++ b/tests/Feature/UdpConnectionTest.php
@@ -38,4 +38,4 @@ it('tests udp connection', function () use ($serverAddress) {
     expect($data)->toBeString('received: xiami');
     fclose($socket);
 })
-    ->skipOnWindows(); //require posix
+    ->skipOnWindows('require posix'); //require posix

--- a/tests/Feature/UdpConnectionTest.php
+++ b/tests/Feature/UdpConnectionTest.php
@@ -38,4 +38,4 @@ it('tests udp connection', function () use ($serverAddress) {
     expect($data)->toBeString('received: xiami');
     fclose($socket);
 })
-    ->skipOnWindows('require posix'); //require posix
+    ->skipOnWindows(); //require posix


### PR DESCRIPTION
So we'll find problems faster for that OSes.


I think that will be good to also add test for each event-loop system(event, swoole, revolt, ...)