### PR TITLE
Fixed bug: onWorkerStop cannot be triggered.

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -36,6 +36,7 @@ use function set_error_handler;
 use function stream_socket_accept;
 use function stream_socket_recvfrom;
 use function substr;
+use function array_walk;
 
 /**
  * Worker class
@@ -1165,7 +1166,7 @@ class Worker
         }
         $signals = [SIGINT, SIGTERM, SIGHUP, SIGTSTP, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO];
         foreach ($signals as $signal) {
-            pcntl_signal($signal, SIG_IGN, false);
+            // Rewrite master process signal.
             static::$globalEvent->onSignal($signal, [static::class, 'signalHandler']);
         }
     }
@@ -1801,7 +1802,7 @@ class Worker
         if (static::$masterPid === posix_getpid()) {
             $sig = static::getGracefulStop() ? SIGUSR2 : SIGUSR1;
             // Set reloading state.
-            if (static::$status !== static::STATUS_RELOADING && static::$status !== static::STATUS_SHUTDOWN) {
+            if (static::$status === static::STATUS_RUNNING) {
                 static::log("Workerman[" . basename(static::$startFile) . "] reloading");
                 static::$status = static::STATUS_RELOADING;
 
@@ -1911,17 +1912,18 @@ class Worker
         else {
             // Execute exit.
             $workers = array_reverse(static::$workers);
-            foreach ($workers as $worker) {
-                if (!$worker->stopping) {
-                    $worker->stop();
-                    $worker->stopping = true;
-                }
-            }
+            array_walk($workers, static fn (Worker $worker) => $worker->stop());
+
             if (!static::getGracefulStop() || ConnectionInterface::$statistics['connection_count'] <= 0) {
                 static::$workers = [];
                 static::$globalEvent?->stop();
 
-                exit($code);
+                try {
+                    // Ignore Swoole ExitException: Swoole exit.
+                    exit($code);
+                } catch(\Exception $e) {
+
+                }
             }
         }
     }
@@ -2457,6 +2459,9 @@ class Worker
      */
     public function stop(): void
     {
+        if ($this->stopping === true) {
+            return;
+        }
         // Try to emit onWorkerStop callback.
         if ($this->onWorkerStop) {
             try {
@@ -2481,6 +2486,7 @@ class Worker
         }
         // Clear callback.
         $this->onMessage = $this->onClose = $this->onError = $this->onBufferDrain = $this->onBufferFull = null;
+        $this->stopping  = true;
     }
 
     /**


### PR DESCRIPTION
1. 修复worker 进程无法触发信号，导致onWorkerStop() 无法执行。
 ```
$signals = [SIGINT, SIGTERM, SIGHUP, SIGTSTP, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO];
foreach ($signals as $signal) {
     //   pcntl_signal($signal, SIG_IGN, false); 移除信号屏蔽，重新注册会重写master 信号。
     // Rewrite master process signal.
    static::$globalEvent->onSignal($signal, [static::class, 'signalHandler']);
}
```
2. 修复swoole exit() 发生异常：
```
onWorkerStart
^CWorkerman[start.php] stopping ...
onWorkerStop
PHP Fatal error:  Uncaught Swoole\ExitException: swoole exit in /mnt/c/users/twomiao/desktop/workerman/src/Worker.php:1921
Stack trace:
#0 /mnt/c/users/twomiao/desktop/workerman/src/Worker.php(1192): Workerman\Worker::stopAll()
#1 [internal function]: Workerman\Worker::signalHandler()
#2 {main}
  thrown in /mnt/c/users/twomiao/desktop/workerman/src/Worker.php on line 1921
worker[none:2878] exit with status 65280
Workerman[start.php] has been stopped
```
`
 try {
       // Ignore Swoole ExitException: Swoole exit.
      exit($code);
      } catch(\Exception $e) {
 }`

3. 复现代码：
```
<?php

use Workerman\Events\Swoole;
use Workerman\Worker;

require __DIR__ . "/vendor/autoload.php";

Worker::$eventLoopClass = Swoole::class;
Worker::$stopTimeout = 15;
$worker = new Worker("http://0.0.0.0:8888");
$worker->count = 1;
$worker->onMessage = static fn ($connection) => $connection->send("hello world");

$worker->onWorkerStart = static fn (Worker $worker) => print "onWorkerStart\n";
$worker->onWorkerStop = static fn (Worker $worker) => print "onWorkerStop\n";
Worker::runAll();
```