### PR TITLE
Network settings in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
         run: composer analyze
 
       - name: Execute tests
-        run: vendor/bin/pest --coverage --colors=always
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,6 @@
     },
     "scripts": {
         "analyze": "phpstan",
-        "test": "pest"
+        "test": "pest --colors=always"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         }
     },
     "scripts": {
-        "analyze": "phpstan"
+        "analyze": "phpstan",
+        "test": "pest"
     }
 }

--- a/tests/Feature/Stub/HttpServer.php
+++ b/tests/Feature/Stub/HttpServer.php
@@ -13,7 +13,7 @@ if (!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
 if (!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
 if (!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
 
-$worker = new Worker('http://0.0.0.0:8080');
+$worker = new Worker('http://127.0.0.1:8080');
 
 $worker->onMessage = function (TcpConnection $connection, Request $request) {
     match ($request->path()) {

--- a/tests/Feature/WebsocketServiceTest.php
+++ b/tests/Feature/WebsocketServiceTest.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 if (!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
 if (!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
 if (!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
-\$worker = new Worker("websocket://0.0.0.0:2000");
+\$worker = new Worker("websocket://127.0.0.1:8081");
 %s
 Worker::\$pidFile = __DIR__ . '/WebsocketServer.pid';
 Worker::\$command = 'start';
@@ -28,7 +28,7 @@ if (!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
 if (!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
 \$worker = new Worker();
 \$worker->onWorkerStart = function(\$worker){
-    \$con = new AsyncTcpConnection('ws://127.0.0.1:2000');
+    \$con = new AsyncTcpConnection('ws://127.0.0.1:8081');
     %s
     \$con->connect();
 };

--- a/tests/Unit/Connection/UdpConnectionTest.php
+++ b/tests/Unit/Connection/UdpConnectionTest.php
@@ -4,7 +4,7 @@ use Workerman\Connection\UdpConnection;
 use Symfony\Component\Process\PhpProcess;
 use Workerman\Protocols\Text;
 
-$remoteAddress = '[::1]:12345';
+$remoteAddress = '127.0.0.1:8082';
 $process = null;
 beforeAll(function () use ($remoteAddress, &$process) {
     $process = new PhpProcess(<<<PHP
@@ -29,8 +29,8 @@ it('tests ' . UdpConnection::class, function () use ($remoteAddress) {
     $udpConnection = new UdpConnection($socketClient, $remoteAddress);
     $udpConnection->protocol = Text::class;
     expect($udpConnection->send('foo'))->toBeTrue()
-        ->and($udpConnection->getRemoteIp())->toBe('::1')
-        ->and($udpConnection->getRemotePort())->toBe(12345)
+        ->and($udpConnection->getRemoteIp())->toBe('127.0.0.1')
+        ->and($udpConnection->getRemotePort())->toBe(8082)
         ->and($udpConnection->getRemoteAddress())->toBe($remoteAddress)
         ->and($udpConnection->getLocalIp())->toBeIn(['::1', '[::1]', '127.0.0.1'])
         ->and($udpConnection->getLocalPort())->toBeInt()


### PR DESCRIPTION
I found some problems with running tests in docker with port 2000 and local ipv6.  
So I changed the test ports to 808* and the listening address to ipv4 to make the test work also on ipv4-only systems.
I also added a "test" script to the composer file.