### PR TITLE
Error handling implemented in all event classes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,11 @@ parameters:
 	            - '#Constant STREAM_POLLNONE not found.#'
 	            - '#Constant STREAM_POLLOUT not found.#'
 	            - '#Property Workerman\\Events\\Swow::.* has unknown class Swow\\Coroutine as its type.#'
+	    -
+	        path: src/Events/Event.php
+	        reportUnmatched: false
+	        messages:
+	            - '#Call to an undefined method EventBase::+.#'
 	    - path: src/Timer.php
 	      message: '#Call to static method getSuspension\(\) on an unknown class Revolt\\EventLoop.#'
 	    - path: tests/Pest.php

--- a/src/Events/EventInterface.php
+++ b/src/Events/EventInterface.php
@@ -11,23 +11,26 @@
  * @link      http://www.workerman.net/
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Workerman\Events;
 
-use Throwable;
+declare(strict_types=1);
+
+namespace Workerman\Events;
 
 interface EventInterface
 {
     /**
      * Delay the execution of a callback.
+     *
      * @param float $delay
-     * @param callable $func
-     * @param mixed[] $args
+     * @param callable(mixed...): void $func
+     * @param array $args
      * @return int
      */
     public function delay(float $delay, callable $func, array $args = []): int;
 
     /**
      * Delete a delay timer.
+     *
      * @param int $timerId
      * @return bool
      */
@@ -35,15 +38,17 @@ interface EventInterface
 
     /**
      * Repeatedly execute a callback.
+     *
      * @param float $interval
-     * @param callable $func
-     * @param mixed[] $args
+     * @param callable(mixed...): void $func
+     * @param array $args
      * @return int
      */
     public function repeat(float $interval, callable $func, array $args = []): int;
 
     /**
      * Delete a repeat timer.
+     *
      * @param int $timerId
      * @return bool
      */
@@ -51,14 +56,16 @@ interface EventInterface
 
     /**
      * Execute a callback when a stream resource becomes readable or is closed for reading.
+     *
      * @param resource $stream
-     * @param callable $func
+     * @param callable(resource): void $func
      * @return void
      */
     public function onReadable($stream, callable $func): void;
 
     /**
      * Cancel a callback of stream readable.
+     *
      * @param resource $stream
      * @return bool
      */
@@ -66,14 +73,16 @@ interface EventInterface
 
     /**
      * Execute a callback when a stream resource becomes writable or is closed for writing.
+     *
      * @param resource $stream
-     * @param callable $func
+     * @param callable(resource): void $func
      * @return void
      */
     public function onWritable($stream, callable $func): void;
 
     /**
      * Cancel a callback of stream writable.
+     *
      * @param resource $stream
      * @return bool
      */
@@ -81,15 +90,16 @@ interface EventInterface
 
     /**
      * Execute a callback when a signal is received.
+     *
      * @param int $signal
-     * @param callable $func
+     * @param callable(int): void $func
      * @return void
-     * @throws Throwable
      */
     public function onSignal(int $signal, callable $func): void;
 
     /**
      * Cancel a callback of signal.
+     *
      * @param int $signal
      * @return bool
      */
@@ -97,39 +107,44 @@ interface EventInterface
 
     /**
      * Delete all timer.
+     *
      * @return void
      */
     public function deleteAllTimer(): void;
 
     /**
      * Run the event loop.
+     *
      * @return void
-     * @throws Throwable
      */
     public function run(): void;
 
     /**
      * Stop event loop.
+     *
      * @return void
      */
     public function stop(): void;
 
     /**
      * Get Timer count.
+     *
      * @return int
      */
     public function getTimerCount(): int;
 
     /**
-     * Set error handler
-     * @param callable $errorHandler
+     * Set error handler.
+     *
+     * @param callable(\Throwable): void $errorHandler
      * @return void
      */
     public function setErrorHandler(callable $errorHandler): void;
 
     /**
      * Get error handler
-     * @return ?callable(Throwable)
+     *
+     * @return null|callable (\Throwable): void
      */
     public function getErrorHandler(): ?callable;
 }

--- a/src/Events/Revolt.php
+++ b/src/Events/Revolt.php
@@ -113,7 +113,7 @@ class Revolt implements EventInterface
     public function delay(float $delay, callable $func, array $args = []): int
     {
         $timerId = $this->timerId++;
-        $closure = static function () use ($func, $args, $timerId) {
+        $closure = function () use ($func, $args, $timerId) {
             unset($this->eventTimer[$timerId]);
             $func(...$args);
         };

--- a/src/Events/Revolt.php
+++ b/src/Events/Revolt.php
@@ -34,30 +34,35 @@ class Revolt implements EventInterface
 
     /**
      * All listeners for read event.
-     * @var array
+     *
+     * @var array<int, string>
      */
     protected array $readEvents = [];
 
     /**
      * All listeners for write event.
-     * @var array
+     *
+     * @var array<int, string>
      */
     protected array $writeEvents = [];
 
     /**
      * Event listeners of signal.
-     * @var array
+     *
+     * @var array<int, string>
      */
     protected array $eventSignal = [];
 
     /**
      * Event listeners of timer.
-     * @var array
+     *
+     * @var array<int, string>
      */
     protected array $eventTimer = [];
 
     /**
      * Timer id.
+     *
      * @var int
      */
     protected int $timerId = 1;
@@ -71,7 +76,7 @@ class Revolt implements EventInterface
     }
 
     /**
-     * Get driver
+     * Get driver.
      *
      * @return Driver
      */
@@ -108,7 +113,7 @@ class Revolt implements EventInterface
     public function delay(float $delay, callable $func, array $args = []): int
     {
         $timerId = $this->timerId++;
-        $closure = function () use ($func, $args, $timerId) {
+        $closure = static function () use ($func, $args, $timerId) {
             unset($this->eventTimer[$timerId]);
             $func(...$args);
         };
@@ -123,10 +128,7 @@ class Revolt implements EventInterface
     public function repeat(float $interval, callable $func, array $args = []): int
     {
         $timerId = $this->timerId++;
-        $closure = function () use ($func, $args) {
-            $func(...$args);
-        };
-        $cbId = $this->driver->repeat($interval, $closure);
+        $cbId = $this->driver->repeat($interval, static fn () => $func(...$args));
         $this->eventTimer[$timerId] = $cbId;
         return $timerId;
     }
@@ -142,9 +144,7 @@ class Revolt implements EventInterface
             unset($this->readEvents[$fdKey]);
         }
 
-        $this->readEvents[$fdKey] = $this->driver->onReadable($stream, function () use ($stream, $func) {
-            $func($stream);
-        });
+        $this->readEvents[$fdKey] = $this->driver->onReadable($stream, static fn () => $func($stream));
     }
 
     /**
@@ -171,9 +171,7 @@ class Revolt implements EventInterface
             $this->driver->cancel($this->writeEvents[$fdKey]);
             unset($this->writeEvents[$fdKey]);
         }
-        $this->writeEvents[$fdKey] = $this->driver->onWritable($stream, function () use ($stream, $func) {
-            $func($stream);
-        });
+        $this->writeEvents[$fdKey] = $this->driver->onWritable($stream, static fn () => $func($stream));
     }
 
     /**
@@ -200,9 +198,7 @@ class Revolt implements EventInterface
             $this->driver->cancel($this->eventSignal[$fdKey]);
             unset($this->eventSignal[$fdKey]);
         }
-        $this->eventSignal[$fdKey] = $this->driver->onSignal($signal, function () use ($signal, $func) {
-            $func($signal);
-        });
+        $this->eventSignal[$fdKey] = $this->driver->onSignal($signal, static fn () => $func($signal));
     }
 
     /**

--- a/src/Events/Swow.php
+++ b/src/Events/Swow.php
@@ -27,12 +27,14 @@ class Swow implements EventInterface
 
     /**
      * All listeners for write event.
+     *
      * @var array<int, Coroutine>
      */
     protected array $writeEvents = [];
 
     /**
      * All listeners for signal.
+     *
      * @var array<int, Coroutine>
      */
     protected array $signalListener = [];

--- a/src/Events/Swow.php
+++ b/src/Events/Swow.php
@@ -4,36 +4,36 @@ declare(strict_types=1);
 
 namespace Workerman\Events;
 
-use RuntimeException;
 use Swow\Coroutine;
 use Swow\Signal;
 use Swow\SignalException;
-use Throwable;
 use function Swow\Sync\waitAll;
 
 class Swow implements EventInterface
 {
     /**
-     * All listeners for read timer
-     * @var array
+     * All listeners for read timer.
+     *
+     * @var array<int, int>
      */
     protected array $eventTimer = [];
 
     /**
      * All listeners for read event.
-     * @var array<Coroutine>
+     *
+     * @var array<int, Coroutine>
      */
     protected array $readEvents = [];
 
     /**
      * All listeners for write event.
-     * @var array<Coroutine>
+     * @var array<int, Coroutine>
      */
     protected array $writeEvents = [];
 
     /**
      * All listeners for signal.
-     * @var array<Coroutine>
+     * @var array<int, Coroutine>
      */
     protected array $signalListener = [];
 
@@ -54,21 +54,15 @@ class Swow implements EventInterface
 
     /**
      * {@inheritdoc}
-     * @throws Throwable
      */
     public function delay(float $delay, callable $func, array $args = []): int
     {
         $t = (int)($delay * 1000);
         $t = max($t, 1);
-        $that = $this;
-        $coroutine = Coroutine::run(function () use ($t, $func, $args, $that): void {
+        $coroutine = Coroutine::run(function () use ($t, $func, $args): void {
             msleep($t);
             unset($this->eventTimer[Coroutine::getCurrent()->getId()]);
-            try {
-                $func(...$args);
-            } catch (Throwable $e) {
-                $that->error($e);
-            }
+            $this->safeCall($func, $args);
         });
         $timerId = $coroutine->getId();
         $this->eventTimer[$timerId] = $timerId;
@@ -77,22 +71,16 @@ class Swow implements EventInterface
 
     /**
      * {@inheritdoc}
-     * @throws Throwable
      */
     public function repeat(float $interval, callable $func, array $args = []): int
     {
         $t = (int)($interval * 1000);
         $t = max($t, 1);
-        $that = $this;
-        $coroutine = Coroutine::run(static function () use ($t, $func, $args, $that): void {
+        $coroutine = Coroutine::run(function () use ($t, $func, $args): void {
             // @phpstan-ignore-next-line While loop condition is always true.
             while (true) {
                 msleep($t);
-                try {
-                    $func(...$args);
-                } catch (Throwable $e) {
-                    $that->error($e);
-                }
+                $this->safeCall($func, $args);
             }
         });
         $timerId = $coroutine->getId();
@@ -156,14 +144,14 @@ class Swow implements EventInterface
                         break;
                     }
                     if ($rEvent !== STREAM_POLLNONE) {
-                        $func($stream);
+                        $this->safeCall($func, [$stream]);
                     }
                     if ($rEvent !== STREAM_POLLIN) {
                         $this->offReadable($stream);
                         break;
                     }
                 }
-            } catch (RuntimeException) {
+            } catch (\RuntimeException) {
                 $this->offReadable($stream);
             }
         });
@@ -201,14 +189,14 @@ class Swow implements EventInterface
                         break;
                     }
                     if ($rEvent !== STREAM_POLLNONE) {
-                        $func($stream);
+                        $this->safeCall($func, [$stream]);
                     }
                     if ($rEvent !== STREAM_POLLOUT) {
                         $this->offWritable($stream);
                         break;
                     }
                 }
-            } catch (RuntimeException) {
+            } catch (\RuntimeException) {
                 $this->offWritable($stream);
             }
         });
@@ -241,8 +229,9 @@ class Swow implements EventInterface
                         $this->signalListener[$signal] !== Coroutine::getCurrent()) {
                         break;
                     }
-                    $func($signal);
+                    $this->safeCall($func, [$signal]);
                 } catch (SignalException) {
+                    // do nothing
                 }
             }
         });
@@ -295,15 +284,20 @@ class Swow implements EventInterface
     }
 
     /**
-     * @param Throwable $e
+     * @param callable $func
+     * @param array $args
      * @return void
-     * @throws Throwable
      */
-    public function error(Throwable $e): void
+    private function safeCall(callable $func, array $args = []): void
     {
-        if (!$this->errorHandler) {
-            throw new $e;
+        try {
+            $func(...$args);
+        } catch (\Throwable $e) {
+            if ($this->errorHandler === null) {
+                echo $e;
+            } else {
+                ($this->errorHandler)($e);
+            }
         }
-        ($this->errorHandler)($e);
     }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2539,16 +2539,16 @@ class Worker
      * For udp package.
      *
      * @param resource $socket
-     * @return bool
+     * @return void
      * @throws Throwable
      */
-    protected function acceptUdpConnection(mixed $socket): bool
+    protected function acceptUdpConnection(mixed $socket): void
     {
         set_error_handler(function () {});
         $recvBuffer = stream_socket_recvfrom($socket, UdpConnection::MAX_UDP_PACKAGE_SIZE, 0, $remoteAddress);
         restore_error_handler();
         if (false === $recvBuffer || empty($remoteAddress)) {
-            return false;
+            return;
         }
         // UdpConnection.
         $connection = new UdpConnection($socket, $remoteAddress);
@@ -2564,7 +2564,7 @@ class Worker
                         while ($recvBuffer !== '') {
                             $len = $parser::input($recvBuffer, $connection);
                             if ($len === 0) {
-                                return true;
+                                return;
                             }
                             $package = substr($recvBuffer, 0, $len);
                             $recvBuffer = substr($recvBuffer, $len);
@@ -2578,7 +2578,7 @@ class Worker
                         $data = $parser::decode($recvBuffer, $connection);
                         // Discard bad packets.
                         if ($data === false) {
-                            return true;
+                            return;
                         }
                         $messageCallback($connection, $data);
                     }
@@ -2590,7 +2590,6 @@ class Worker
                 static::stopAll(250, $e);
             }
         }
-        return true;
     }
 
     /**


### PR DESCRIPTION
I found out that throwing errors in Event classes was not handled in all cases although errorHandler is provided by interface.  
Errors was only handled for delays, not for streams, and it was also not implemented in every Event class.  
So in this mr I have implemented error handling in every Event class in every case including stream events to use provided errorHandler.  
I also did some codestyle fixes and described types in doc block more strictly.