### PR TITLE
Events finalize

### DIFF
--- a/src/Events/Ev.php
+++ b/src/Events/Ev.php
@@ -219,14 +219,6 @@ final class Ev implements EventInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getErrorHandler(): ?callable
-    {
-        return $this->errorHandler;
-    }
-
-    /**
      * @param callable $func
      * @param array $args
      * @return void

--- a/src/Events/Ev.php
+++ b/src/Events/Ev.php
@@ -18,47 +18,47 @@ namespace Workerman\Events;
 /**
  * Ev eventloop
  */
-class Ev implements EventInterface
+final class Ev implements EventInterface
 {
     /**
      * All listeners for read event.
      *
      * @var array<int, \EvIo>
      */
-    protected array $readEvents = [];
+    private array $readEvents = [];
 
     /**
      * All listeners for write event.
      *
      * @var array<int, \EvIo>
      */
-    protected array $writeEvents = [];
+    private array $writeEvents = [];
 
     /**
      * Event listeners of signal.
      *
      * @var array<int, \EvSignal>
      */
-    protected array $eventSignal = [];
+    private array $eventSignal = [];
 
     /**
      * All timer event listeners.
      *
      * @var array<int, \EvTimer>
      */
-    protected array $eventTimer = [];
+    private array $eventTimer = [];
 
     /**
      * @var ?callable
      */
-    protected $errorHandler = null;
+    private $errorHandler = null;
 
     /**
      * Timer id.
      *
      * @var int
      */
-    protected static int $timerId = 1;
+    private static int $timerId = 1;
 
     /**
      * {@inheritdoc}

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -273,14 +273,6 @@ final class Event implements EventInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getErrorHandler(): ?callable
-    {
-        return $this->errorHandler;
-    }
-
-    /**
      * @param callable $func
      * @param array $args
      * @return void

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -19,61 +19,61 @@ namespace Workerman\Events;
 /**
  * libevent eventloop
  */
-class Event implements EventInterface
+final class Event implements EventInterface
 {
     /**
      * Event base.
      *
      * @var \EventBase
      */
-    protected \EventBase $eventBase;
+    private \EventBase $eventBase;
 
     /**
      * All listeners for read event.
      *
      * @var array<int, \Event>
      */
-    protected array $readEvents = [];
+    private array $readEvents = [];
 
     /**
      * All listeners for write event.
      *
      * @var array<int, \Event>
      */
-    protected array $writeEvents = [];
+    private array $writeEvents = [];
 
     /**
      * Event listeners of signal.
      *
      * @var array<int, \Event>
      */
-    protected array $eventSignal = [];
+    private array $eventSignal = [];
 
     /**
      * All timer event listeners.
      *
      * @var array<int, \Event>
      */
-    protected array $eventTimer = [];
+    private array $eventTimer = [];
 
     /**
      * Timer id.
      *
      * @var int
      */
-    protected int $timerId = 0;
+    private int $timerId = 0;
 
     /**
      * Event class name.
      *
      * @var string
      */
-    protected string $eventClassName = '';
+    private string $eventClassName = '';
 
     /**
      * @var ?callable
      */
-    protected $errorHandler = null;
+    private $errorHandler = null;
 
     /**
      * Construct.

--- a/src/Events/EventInterface.php
+++ b/src/Events/EventInterface.php
@@ -140,11 +140,4 @@ interface EventInterface
      * @return void
      */
     public function setErrorHandler(callable $errorHandler): void;
-
-    /**
-     * Get error handler
-     *
-     * @return null|callable (\Throwable): void
-     */
-    public function getErrorHandler(): ?callable;
 }

--- a/src/Events/Revolt.php
+++ b/src/Events/Revolt.php
@@ -25,47 +25,47 @@ use function pcntl_signal;
 /**
  * Revolt eventloop
  */
-class Revolt implements EventInterface
+final class Revolt implements EventInterface
 {
     /**
      * @var Driver
      */
-    protected Driver $driver;
+    private Driver $driver;
 
     /**
      * All listeners for read event.
      *
      * @var array<int, string>
      */
-    protected array $readEvents = [];
+    private array $readEvents = [];
 
     /**
      * All listeners for write event.
      *
      * @var array<int, string>
      */
-    protected array $writeEvents = [];
+    private array $writeEvents = [];
 
     /**
      * Event listeners of signal.
      *
      * @var array<int, string>
      */
-    protected array $eventSignal = [];
+    private array $eventSignal = [];
 
     /**
      * Event listeners of timer.
      *
      * @var array<int, string>
      */
-    protected array $eventTimer = [];
+    private array $eventTimer = [];
 
     /**
      * Timer id.
      *
      * @var int
      */
-    protected int $timerId = 1;
+    private int $timerId = 1;
 
     /**
      * Construct.

--- a/src/Events/Revolt.php
+++ b/src/Events/Revolt.php
@@ -262,12 +262,4 @@ final class Revolt implements EventInterface
     {
         $this->driver->setErrorHandler($errorHandler);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrorHandler(): ?callable
-    {
-        return $this->driver->getErrorHandler();
-    }
 }

--- a/src/Events/Select.php
+++ b/src/Events/Select.php
@@ -26,61 +26,61 @@ use const DIRECTORY_SEPARATOR;
 /**
  * select eventloop
  */
-class Select implements EventInterface
+final class Select implements EventInterface
 {
     /**
      * Running.
      *
      * @var bool
      */
-    protected bool $running = true;
+    private bool $running = true;
 
     /**
      * All listeners for read/write event.
      *
      * @var array<int, callable>
      */
-    protected array $readEvents = [];
+    private array $readEvents = [];
 
     /**
      * All listeners for read/write event.
      *
      * @var array<int, callable>
      */
-    protected array $writeEvents = [];
+    private array $writeEvents = [];
 
     /**
      * @var array<int, callable>
      */
-    protected array $exceptEvents = [];
+    private array $exceptEvents = [];
 
     /**
      * Event listeners of signal.
      *
      * @var array<int, callable>
      */
-    protected array $signalEvents = [];
+    private array $signalEvents = [];
 
     /**
      * Fds waiting for read event.
      *
      * @var array<int, resource>
      */
-    protected array $readFds = [];
+    private array $readFds = [];
 
     /**
      * Fds waiting for write event.
      *
      * @var array<int, resource>
      */
-    protected array $writeFds = [];
+    private array $writeFds = [];
 
     /**
      * Fds waiting for except event.
      *
      * @var array<int, resource>
      */
-    protected array $exceptFds = [];
+    private array $exceptFds = [];
 
     /**
      * Timer scheduler.
@@ -88,7 +88,7 @@ class Select implements EventInterface
      *
      * @var \SplPriorityQueue
      */
-    protected \SplPriorityQueue $scheduler;
+    private \SplPriorityQueue $scheduler;
 
     /**
      * All timer event listeners.
@@ -96,26 +96,26 @@ class Select implements EventInterface
      *
      * @var array
      */
-    protected array $eventTimer = [];
+    private array $eventTimer = [];
 
     /**
      * Timer id.
      *
      * @var int
      */
-    protected int $timerId = 1;
+    private int $timerId = 1;
 
     /**
      * Select timeout.
      *
      * @var int
      */
-    protected int $selectTimeout = 100000000;
+    private int $selectTimeout = 100000000;
 
     /**
      * @var ?callable
      */
-    protected $errorHandler = null;
+    private $errorHandler = null;
 
     /**
      * Construct.

--- a/src/Events/Select.php
+++ b/src/Events/Select.php
@@ -442,14 +442,6 @@ final class Select implements EventInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getErrorHandler(): ?callable
-    {
-        return $this->errorHandler;
-    }
-
-    /**
      * @param callable $func
      * @param array $args
      * @return void

--- a/src/Events/Swoole.php
+++ b/src/Events/Swoole.php
@@ -19,33 +19,33 @@ use Swoole\Event;
 use Swoole\Process;
 use Swoole\Timer;
 
-class Swoole implements EventInterface
+final class Swoole implements EventInterface
 {
     /**
      * All listeners for read timer
      *
      * @var array<int, int>
      */
-    protected array $eventTimer = [];
+    private array $eventTimer = [];
 
     /**
      * All listeners for read event.
      *
      * @var array<int, resource>
      */
-    protected array $readEvents = [];
+    private array $readEvents = [];
 
     /**
      * All listeners for write event.
      *
      * @var array<int, resource>
      */
-    protected array $writeEvents = [];
+    private array $writeEvents = [];
 
     /**
      * @var ?callable
      */
-    protected $errorHandler = null;
+    private $errorHandler = null;
 
     /**
      * {@inheritdoc}

--- a/src/Events/Swoole.php
+++ b/src/Events/Swoole.php
@@ -234,14 +234,6 @@ final class Swoole implements EventInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getErrorHandler(): ?callable
-    {
-        return $this->errorHandler;
-    }
-
-    /**
      * @param callable $func
      * @param array $args
      * @return void

--- a/src/Events/Swow.php
+++ b/src/Events/Swow.php
@@ -9,38 +9,38 @@ use Swow\Signal;
 use Swow\SignalException;
 use function Swow\Sync\waitAll;
 
-class Swow implements EventInterface
+final class Swow implements EventInterface
 {
     /**
      * All listeners for read timer.
      *
      * @var array<int, int>
      */
-    protected array $eventTimer = [];
+    private array $eventTimer = [];
 
     /**
      * All listeners for read event.
      *
      * @var array<int, Coroutine>
      */
-    protected array $readEvents = [];
+    private array $readEvents = [];
 
     /**
      * All listeners for write event.
      * @var array<int, Coroutine>
      */
-    protected array $writeEvents = [];
+    private array $writeEvents = [];
 
     /**
      * All listeners for signal.
      * @var array<int, Coroutine>
      */
-    protected array $signalListener = [];
+    private array $signalListener = [];
 
     /**
      * @var ?callable
      */
-    protected $errorHandler = null;
+    private $errorHandler = null;
 
     /**
      * Get timer count.

--- a/src/Events/Swow.php
+++ b/src/Events/Swow.php
@@ -276,14 +276,6 @@ final class Swow implements EventInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getErrorHandler(): ?callable
-    {
-        return $this->errorHandler;
-    }
-
-    /**
      * @param callable $func
      * @param array $args
      * @return void


### PR DESCRIPTION
I suggest to finalize Event classes. Inheritance for them seems not very much useful and even unwanted since we have Interface. User can implement Interface and use own implementation if it needed instead of inheriting from package implementations.  
I believe it's possible now while version 5 is still in beta.
I also suggest to remove getErrorHandler method from Interface since it don't used here.