### PR TITLE
Tests improvements: Udp and websocket server code stubs moved out to Stub directory

### DIFF
--- a/tests/Feature/HttpConnectionTest.php
+++ b/tests/Feature/HttpConnectionTest.php
@@ -7,10 +7,9 @@ use Symfony\Component\Process\PhpProcess;
 
 $process = null;
 beforeAll(function () use (&$process) {
-    $code = file_get_contents(__DIR__ . '/Stub/HttpServer.php');
-    $process = new PhpProcess($code);
+    $process = new PhpProcess(file_get_contents(__DIR__ . '/Stub/HttpServer.php'));
     $process->start();
-    sleep(1);
+    usleep(250000);
 });
 
 afterAll(function () use (&$process) {

--- a/tests/Feature/Stub/HttpServer.php
+++ b/tests/Feature/Stub/HttpServer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;

--- a/tests/Feature/Stub/UdpServer.php
+++ b/tests/Feature/Stub/UdpServer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Workerman\Worker;
+
+require './vendor/autoload.php';
+
+if(!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
+if(!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
+if(!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
+
+$server = new Worker('udp://127.0.0.1:8083');
+
+$server->onMessage = function ($connection, $data) {
+    $connection->send('received: ' . $data);
+};
+
+Worker::$command = 'start';
+Worker::runAll();

--- a/tests/Feature/Stub/WebsocketClient.php
+++ b/tests/Feature/Stub/WebsocketClient.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Workerman\Connection\AsyncTcpConnection;
+use Workerman\Worker;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+if (!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
+if (!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
+if (!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
+
+$worker = new Worker();
+$worker->onWorkerStart = function($worker) {
+    $con = new AsyncTcpConnection('ws://127.0.0.1:8081');
+    //%action%
+    $con->connect();
+};
+
+Worker::$pidFile = sprintf('%s/test-websocket-client.pid', sys_get_temp_dir());
+Worker::$command = 'start';
+Worker::runAll();

--- a/tests/Feature/Stub/WebsocketServer.php
+++ b/tests/Feature/Stub/WebsocketServer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Workerman\Connection\TcpConnection;
+use Workerman\Protocols\Http\Request;
+use Workerman\Worker;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+if (!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
+if (!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
+if (!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
+
+$worker = new Worker("websocket://127.0.0.1:8081");
+//%action%
+
+Worker::$pidFile = sprintf('%s/test-websocket-server.pid', sys_get_temp_dir());
+Worker::$command = 'start';
+Worker::runAll();

--- a/tests/Feature/UdpConnectionTest.php
+++ b/tests/Feature/UdpConnectionTest.php
@@ -1,29 +1,12 @@
 <?php
 
 use Symfony\Component\Process\PhpProcess;
-use Workerman\Worker;
 
-$serverAddress = 'udp://127.0.0.1:6789';
 $process = null;
-beforeAll(function () use ($serverAddress, &$process) {
-    $process = new PhpProcess(<<<PHP
-        <?php    
-        if(!defined('STDIN')) define('STDIN', fopen('php://stdin', 'r'));
-        if(!defined('STDOUT')) define('STDOUT', fopen('php://stdout', 'w'));
-        if(!defined('STDERR')) define('STDERR', fopen('php://stderr', 'w'));
-        require './vendor/autoload.php';
-        use Workerman\Worker;
-        
-        \$server = new Worker('$serverAddress');
-        \$server->onMessage = function (\$connection, \$data) {
-            \$connection->send('received: '.\$data);
-        };
-        Worker::\$command = 'start';
-        Worker::runAll();
-    PHP
-    );
+beforeAll(function () use (&$process) {
+    $process = new PhpProcess(file_get_contents(__DIR__ . '/Stub/UdpServer.php'));
     $process->start();
-    sleep(1);
+    usleep(250000);
 });
 
 afterAll(function () use (&$process) {
@@ -31,8 +14,8 @@ afterAll(function () use (&$process) {
     $process->stop();
 });
 
-it('tests udp connection', function () use ($serverAddress) {
-    $socket = stream_socket_client($serverAddress, $errno, $errstr, 1);
+it('tests udp connection', function () {
+    $socket = stream_socket_client('udp://127.0.0.1:8083', $errno, $errstr, 1);
     expect($errno)->toBeInt()->toBe(0);
     fwrite($socket, 'xiami');
     $data = fread($socket, 1024);

--- a/tests/Unit/Connection/UdpConnectionTest.php
+++ b/tests/Unit/Connection/UdpConnectionTest.php
@@ -16,7 +16,7 @@ beforeAll(function () use ($remoteAddress, &$process) {
     PHP
     );
     $process->start();
-    sleep(1);
+    usleep(250000);
 });
 
 afterAll(function () use (&$process) {


### PR DESCRIPTION
Moved out Udp and websocket server code stubs to Stub directory for better code readability.
Decreased sleep timers from 1sec to 0.25sec, which should be enough. This small change reduced the tests runtime from 22sec to 13sec.