### PR TITLE
Fixed issue when child process has signal handlers installed, they where ignored.

### DIFF
--- a/src/Events/Select.php
+++ b/src/Events/Select.php
@@ -366,7 +366,9 @@ final class Select implements EventInterface
             if (!empty($read) || !empty($write) || !empty($except)) {
                 // Waiting read/write/signal/timeout events.
                 try {
-                    @stream_select($read, $write, $except, 0, $this->selectTimeout);
+                    if (@stream_select($read, $write, $except, 0, $this->selectTimeout) === false) {
+						continue;
+					}
                 } catch (\Throwable) {
                     // do nothing
                 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1221,6 +1221,8 @@ class Worker
         if (DIRECTORY_SEPARATOR !== '/') {
             return;
         }
+		pcntl_async_signals(true);
+
         $signals = [SIGINT, SIGTERM, SIGHUP, SIGTSTP, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO];
         foreach ($signals as $signal) {
             pcntl_signal($signal, static::signalHandler(...), false);


### PR DESCRIPTION
Fixed issue with child process having custom handlers. When signal is called with child process `PID`, it cancels the sleep but handlers wont be called.
Improved default select with `stream_select` error check.

Simple test, commenting `pcntl_async_signals` will result `sleep` disrupted but handler wont be called.
Same is with Workerman, it waits for stream_select and when signal is called it breaks the select, but handlers wont be called.

```
<?php
pcntl_async_signals(true);

function sig_handler(int $signal, mixed $siginfo): void
{
	var_dump($siginfo);
	echo 'Yolo';
	fwrite(STDOUT, "Received singal $signal". PHP_EOL);
	fwrite(STDERR, "Received singal $signal". PHP_EOL);
	fflush(STDOUT);
	fflush(STDERR);
}
// pm2 sends SIGINT as quit signal
pcntl_signal(SIGINT, 'sig_handler');
pcntl_signal(SIGTERM, 'sig_handler');
pcntl_signal(SIGUSR1, 'sig_handler');

while (true) {
	echo 'sleeping 100'. PHP_EOL;
	sleep(100);
	echo 'woke up'. PHP_EOL;
	posix_kill(posix_getpid(), SIGUSR1);
}
```

In CLI run command `kill -s 15 PID`
