### PR TITLE
worker: allow to set logFile as /dev/null

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -662,7 +662,7 @@ class Worker
         // Log file.
         static::$logFile ??= sprintf('%s/workerman.log', dirname(__DIR__, 2));
 
-        if (!is_file(static::$logFile)) {
+        if (!is_file(static::$logFile) && static::$logFile !== '/dev/null') {
             // if /runtime/logs  default folder not exists
             if (!is_dir(dirname(static::$logFile))) {
                 @mkdir(dirname(static::$logFile), 0777, true);


### PR DESCRIPTION
This small code allows to use /dev/null as logFile

```php
Worker::$logFile = '/dev/null';
```