### PR TITLE
Fix error when unserialize return false

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1142,6 +1142,9 @@ class Worker
         } catch (Throwable) {
             // do nothing
         }
+        if (!is_array($workerInfo)) {
+            $workerInfo = [];
+        }
         ksort($workerInfo, SORT_NUMERIC);
         unset($info[0]);
         $dataWaitingSort = [];


### PR DESCRIPTION
Double check the workerInfo var.
In some cases, the unserialize will notice some tips like: unserialize(): Error at offset 0 of 54 bytes in file, but dont throw any Exception.