### PR TITLE
fix:修复header等于Transfer-Encoding:Chunk 状态下Connection等于close时，输出流未给出chu…

### DIFF
--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -468,6 +468,9 @@ class Response implements Stringable
         if (!isset($headers['Transfer-Encoding'])) {
             $head .= "Content-Length: $bodyLen\r\n\r\n";
         } else {
+            if (isset($headers['Connection']) && $headers['Connection'] == 'close') {
+                return $bodyLen ? "$head\r\n" . dechex($bodyLen) . "\r\n{$this->body}\r\n0\r\n\r\n" : "$head\r\n";
+            }
             return $bodyLen ? "$head\r\n" . dechex($bodyLen) . "\r\n{$this->body}\r\n" : "$head\r\n";
         }
 


### PR DESCRIPTION
修复header等于Transfer-Encoding:Chunk 状态下 Connection等于close时，输出流未给出chunk结束标识的问题。