### PR TITLE
Fix run-os in github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   linux_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Just found out that the github actions file is probably configured incorrectly.
It should probably to be run on ubuntu, macos and windows but it only runs on ubuntu in all cases.

The bad news is that the tests fail on macos and windows.

![image](https://github.com/walkor/workerman/assets/25800964/4942c13b-3ef2-4d51-99c4-d0f9d9a3b7d1)
