### PR TITLE
Added exit code information message to master process and resolved signals propagation issue.

### DIFF
--- a/src/Events/Select.php
+++ b/src/Events/Select.php
@@ -367,8 +367,8 @@ final class Select implements EventInterface
                 // Waiting read/write/signal/timeout events.
                 try {
                     if (@stream_select($read, $write, $except, 0, $this->selectTimeout) === false) {
-						continue;
-					}
+                        continue;
+                    }
                 } catch (\Throwable) {
                     // do nothing
                 }

--- a/src/Events/Select.php
+++ b/src/Events/Select.php
@@ -366,7 +366,9 @@ final class Select implements EventInterface
             if (!empty($read) || !empty($write) || !empty($except)) {
                 // Waiting read/write/signal/timeout events.
                 try {
-                    @stream_select($read, $write, $except, 0, $this->selectTimeout);
+                    if (@stream_select($read, $write, $except, 0, $this->selectTimeout) === false) {
+						continue;
+					}
                 } catch (\Throwable) {
                     // do nothing
                 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1214,21 +1214,22 @@ class Worker
     /**
      * Install signal handler.
      *
+     * @param bool $restartSysCalls
      * @return void
      */
-    protected static function installSignal(): void
+    protected static function installSignal(bool $restartSysCalls = false): void
     {
         if (DIRECTORY_SEPARATOR !== '/') {
             return;
         }
-		pcntl_async_signals(true);
+        pcntl_async_signals(true);
 
         $signals = [SIGINT, SIGTERM, SIGHUP, SIGTSTP, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO];
         foreach ($signals as $signal) {
-            pcntl_signal($signal, static::signalHandler(...), false);
+            pcntl_signal($signal, static::signalHandler(...), $restartSysCalls);
         }
         // ignore
-        pcntl_signal(SIGPIPE, SIG_IGN, false);
+        pcntl_signal(SIGPIPE, SIG_IGN, $restartSysCalls);
     }
 
     /**
@@ -1242,15 +1243,7 @@ class Worker
         if (DIRECTORY_SEPARATOR !== '/') {
             return;
         }
-		pcntl_async_signals(true);
-
-        $signals = [SIGINT, SIGTERM, SIGHUP, SIGTSTP, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO];
-        foreach ($signals as $signal) {
-            // Rewrite master process signal.
-            static::$globalEvent->onSignal($signal, static::signalHandler(...));
-        }
-		// ignore
-		pcntl_signal(SIGPIPE, SIG_IGN, false);
+        self::installSignal(true);
     }
 
     /**

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1221,6 +1221,8 @@ class Worker
         if (DIRECTORY_SEPARATOR !== '/') {
             return;
         }
+		pcntl_async_signals(true);
+
         $signals = [SIGINT, SIGTERM, SIGHUP, SIGTSTP, SIGQUIT, SIGUSR1, SIGUSR2, SIGIOT, SIGIO];
         foreach ($signals as $signal) {
             pcntl_signal($signal, static::signalHandler(...), false);


### PR DESCRIPTION
`reinstallSignals` had duplicated code with `installSignals`.
There is no need to continue when `select_stream` returns false, occasionally receives `SIGPIPE` which should be ignored.
Added `pcntl_async_signals(true);` cause when running Workerman as a library, signals wont reach Workerman nor the master service wrapping Workerman.
These code changes are in production environment, and service is now working without problems.