### PR TITLE
Response construct use property promotion

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -248,7 +248,7 @@ class Http
             }
             $handler = fopen($file, 'r');
             if (false === $handler) {
-                $connection->close(new Response(403, null, '403 Forbidden'));
+                $connection->close(new Response(403, [], '403 Forbidden'));
                 return '';
             }
             $connection->send((string)$response, true);

--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -39,19 +39,6 @@ use const FILE_SKIP_EMPTY_LINES;
  */
 class Response implements Stringable
 {
-    /**
-     * Header data.
-     *
-     * @var array
-     */
-    protected array $headers = [];
-
-    /**
-     * Http status.
-     *
-     * @var int
-     */
-    protected int $status;
 
     /**
      * Http reason.
@@ -66,13 +53,6 @@ class Response implements Stringable
      * @var string
      */
     protected string $version = '1.1';
-
-    /**
-     * Http body.
-     *
-     * @var string
-     */
-    protected string $body = '';
 
     /**
      * Send file info
@@ -177,20 +157,15 @@ class Response implements Stringable
     /**
      * Response constructor.
      *
-     * @param int $status
-     * @param array|null $headers
+     * @param int    $status
+     * @param array  $headers
      * @param string $body
      */
     public function __construct(
-        int     $status = 200,
-        ?array  $headers = [],
-        string  $body = ''
-    )
-    {
-        $this->status = $status;
-        $this->headers = $headers;
-        $this->body = $body;
-    }
+        protected int    $status = 200,
+        protected array  $headers = [],
+        protected string $body = ''
+    ) {}
 
     /**
      * Set header.


### PR DESCRIPTION
Also fix a problem with the last `__construct`, that permit `array|null`  in `$headers` and later this will break.

Before:

```php
protected array $headers = [];

    /**
     * Response constructor.
     *
     * @param int $status
     * @param array|null $headers
     * @param string $body
     */
 public function __construct(
        int     $status = 200,
        ?array  $headers = [],
        string  $body = ''
    )
    {
        $this->status = $status;
        $this->headers = $headers;
        $this->body = $body;
    }

```
`$this->headers = $headers;` will break if we send a `null`.

And if we permit `null`, we have more problems in the class.

Example:
```php
public function getHeaders(): array
    {
        return $this->headers;
    }
...
```