### PR TITLE
fix: all coroutines must be canceled before Event::exit

### DIFF
--- a/src/Events/Swoole.php
+++ b/src/Events/Swoole.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Workerman\Events;
 
+use Swoole\Coroutine;
 use Swoole\Event;
 use Swoole\Process;
 use Swoole\Timer;
@@ -211,6 +212,10 @@ final class Swoole implements EventInterface
      */
     public function stop(): void
     {
+        // cancel all coroutines before Event::exit
+        foreach (Coroutine::listCoroutines() as $coroutine) {
+            Coroutine::cancel($coroutine);
+        }
         Event::exit();
         posix_kill(posix_getpid(), SIGINT);
     }


### PR DESCRIPTION
在webman的协程基建插件（ https://www.workerman.net/plugin/167 ）的测试中发现，使用channel、waitGroup组件或者被hook的系统函数如sleep进行处理业务时，在退出workerman时会发生`[FATAL ERROR]: all coroutines (count: N) are asleep - deadlock!`（其中的N是退出时的协程数量）等错误；
可能的错误还有：
- WARNING Channel::~Channel() (ERRNO 10003): channel is destroyed, 1 consumers will be discarded
- Fatal error: Uncaught Swoole\Error: API must be called in the coroutine in @swoole/library/core/Coroutine/WaitGroup.php


webman协程基建插件后续对于swow、swoole事件的测试反馈会持续跟进提交到workerman。

另外，协程基建目前做的不仅针对于webman的协程化，还提供了workerman的worker/server的协程化。