### PR TITLE
Give the ability for status call to output in JSON format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 /phpstan.neon
 /*.pid
 /*.pid.lock
+nbproject/

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1267,9 +1267,9 @@ class Worker
                     $arr[$gsKey]['Event'] = $matches[2];
                 } elseif( preg_match('/^(\d+) workers\s+(\d+) processes/', $line, $matches ) &&
                         array_key_exists(1,$matches) && array_key_exists(2,$matches) ){
-                    $arr[$gsKey]['Workers'] = [ 'Count' => $matches[1], 'Processes' => $matches[2],
+                    $arr[$gsKey]['Workers'] = [ 'Count' => intval($matches[1]), 'Processes' => intval($matches[2]),
                         'Records' => [] ];
-                    $arr[$pKey]['Count'] = $matches[2];
+                    $arr[$pKey]['Count'] = intval($matches[2]);
                 }
             } elseif( $currStatus === 'WORKER' ){
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -310,8 +310,8 @@ class Worker
      *
      * @var bool
      */
-    public static bool $jsonLog = false;    
-    
+    public static bool $jsonLog = false;
+
     /**
      * Global event loop.
      *
@@ -993,7 +993,7 @@ class Worker
             '-g'
         ];
         $availableLog = ['-jl'];
-        
+
         $command = $mode = '';
         foreach (static::getArgv() as $value) {
             if (!$command && in_array($value, $availableCommands)) {
@@ -1001,7 +1001,7 @@ class Worker
             }
             if (!$mode && in_array($value, $availableMode)) {
                 $mode = $value;
-            } 
+            }
             if (in_array($value, $availableLog)) {
                 static::$jsonLog = true;
             }
@@ -1233,12 +1233,12 @@ class Worker
         $arr = [ $gsKey => [], $pKey => ['Records' => []] ];
         $currStatus = null;
         $processKeys = [];
-        
+
         $lines = explode("\n", $statusStr );
-        
+
         foreach($lines as $line){
             $matches = [];
-            
+
             if(preg_match('/GLOBAL STATUS/', $line)){
                 $currStatus = 'GLOBAL';
                 continue;
@@ -1252,7 +1252,7 @@ class Worker
                 $currStatus = 'SUMMARY';
                 continue;
             }
-            
+
             if( $currStatus === 'GLOBAL' ){
                 if( preg_match('/^Workerman version:(\S+)\s+PHP version:(\S+)/', $line, $matches ) &&
                         array_key_exists(1,$matches) && array_key_exists(2,$matches) ){
@@ -1272,72 +1272,72 @@ class Worker
                     $arr[$pKey]['Count'] = $matches[2];
                 }
             } elseif( $currStatus === 'WORKER' ){
-                
+
                 if( preg_match('/^(.*?)\s(\d)\s+(\d)/', $line, $matches ) &&
                         array_key_exists(1,$matches) && array_key_exists(2,$matches) && array_key_exists(3,$matches) ){
 
-                    $arr[$gsKey]['Workers']['Records'][] = ['Name' => rtrim($matches[1]), 
+                    $arr[$gsKey]['Workers']['Records'][] = ['Name' => rtrim($matches[1]),
                                                                     'Exit Status' => intval($matches[2]),
                                                                     'Exit Count' => intval($matches[3])];
                 }
             } elseif( $currStatus === 'PROCESS' ){
                 if(preg_match('/^pid\s+memory\s+listening/', $line)) {
-                    preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*)/', 
-                          $line, 
+                    preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*)/',
+                          $line,
                           $matches );
-                
+
                     if( count($matches) < 3 ){
                         continue;
                     }
-                    
+
                     for($i = 1; $i < count($matches); $i++ ){
                         $processKeys[$i] = $matches[$i];
                     }
-                    
-                } elseif( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/', 
+
+                } elseif( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/',
                           $line, 
                           $matches ) ){
-                    
+
                     if( count($processKeys) !== count($matches) - 1  || count($processKeys) < 3 ){
                         //header row column count did not match row count
                         continue;
                     }
                     $pArr = [];
-                    
+
                     for( $i = 1; $i <= count($processKeys); $i++ ){
                         $pArr[$processKeys[$i]] = ( is_numeric($matches[$i]) ? intval($matches[$i]) : $matches[$i] );
                     }
-                    $arr[$pKey]['Records'][] = $pArr;  
+                    $arr[$pKey]['Records'][] = $pArr;
                 }
 
             } elseif( $currStatus === 'SUMMARY') {
-                if( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/', 
-                          $line, 
+                if( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/',
+                          $line,
                           $matches ) ){
-                
+
                     if( count($processKeys) !== count($matches) - 1 || count($processKeys) < 3 ){
                         //header row column count did not match row count
                         continue;
                     }
-                    
+
                     $pArr = [];
-                    
+
                     for( $i = 2; $i < count($processKeys); $i++ ){
                         if( $matches[$i] === '-' ){
                             continue;
                         }
                         $pArr[$processKeys[$i]] = ( is_numeric($matches[$i]) ? intval($matches[$i]) : $matches[$i] );
                     }
-        
+
                     $arr[$pKey]['Summary'] = $pArr;  
                 }
             }
         }
 
         return json_encode($arr, JSON_PRETTY_PRINT);
-        
-    }    
-    
+
+    }
+
     protected static function formatConnectionStatusData(): string
     {
         return file_get_contents(static::$connectionsFile);

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -306,6 +306,13 @@ class Worker
     public static string $logFile;
 
     /**
+     * Log in JSON.
+     *
+     * @var bool
+     */
+    public static bool $jsonLog = false;    
+    
+    /**
      * Global event loop.
      *
      * @var ?EventInterface
@@ -972,7 +979,7 @@ class Worker
 
         // Check argv;
         $startFile = basename(static::$startFile);
-        $usage = "Usage: php yourfile <command> [mode]\nCommands: \nstart\t\tStart worker in USER mode.\n\t\tUse mode -d to start in DAEMON mode.\nstop\t\tStop worker.\n\t\tUse mode -g to stop gracefully.\nrestart\t\tRestart workers.\n\t\tUse mode -d to start in DAEMON mode.\n\t\tUse mode -g to stop gracefully.\nreload\t\tReload codes.\n\t\tUse mode -g to reload gracefully.\nstatus\t\tGet worker status.\n\t\tUse mode -d to show live status.\nconnections\tGet worker connections.\n";
+        $usage = "Usage: php yourfile <command> [mode]\nCommands: \nstart\t\tStart worker in USER mode.\n\t\tUse mode -d to start in DAEMON mode.\nstop\t\tStop worker.\n\t\tUse mode -g to stop gracefully.\nrestart\t\tRestart workers.\n\t\tUse mode -d to start in DAEMON mode.\n\t\tUse mode -g to stop gracefully.\nreload\t\tReload codes.\n\t\tUse mode -g to reload gracefully.\nstatus\t\tGet worker status.\n\t\tUse switch -d to show live status.\n\t\tUse flag -jl to print log in JSON.\\nconnections\tGet worker connections.\n";
         $availableCommands = [
             'start',
             'stop',
@@ -985,6 +992,8 @@ class Worker
             '-d',
             '-g'
         ];
+        $availableLog = ['-jl'];
+        
         $command = $mode = '';
         foreach (static::getArgv() as $value) {
             if (!$command && in_array($value, $availableCommands)) {
@@ -992,6 +1001,9 @@ class Worker
             }
             if (!$mode && in_array($value, $availableMode)) {
                 $mode = $value;
+            } 
+            if (in_array($value, $availableLog)) {
+                static::$jsonLog = true;
             }
         }
 
@@ -1211,9 +1223,121 @@ class Worker
             . str_pad((string)$totalConnections, 11) . " " . str_pad((string)$totalFails, 9) . " "
             . str_pad((string)$totalTimers, 7) . " " . str_pad((string)$totalRequests, 13) . " "
             . str_pad((string)$totalQps, 6) . " [Summary] \n";
-        return $statusStr;
+         return ( static::$jsonLog === true ? self::formatConnectionStatusDataJson($statusStr) : $statusStr );
     }
 
+    protected static function formatConnectionStatusDataJson( string $statusStr ): string
+    {
+        $gsKey = 'Global Status';
+        $pKey = 'Processes';
+        $arr = [ $gsKey => [], $pKey => ['Records' => []] ];
+        $currStatus = null;
+        $processKeys = [];
+        
+        $lines = explode("\n", $statusStr );
+        
+        foreach($lines as $line){
+            $matches = [];
+            
+            if(preg_match('/GLOBAL STATUS/', $line)){
+                $currStatus = 'GLOBAL';
+                continue;
+            } elseif(preg_match('/^worker_name\s+exit_status\s+exit_count/', $line) && $currStatus === 'GLOBAL') {
+                $currStatus = 'WORKER';
+                continue;
+            } elseif(preg_match('/PROCESS STATUS/', $line) && $currStatus === 'WORKER') {
+                $currStatus = 'PROCESS';
+                continue;
+            } elseif(preg_match('/PROCESS STATUS/', $line) && $currStatus === 'PROCESS') {
+                $currStatus = 'SUMMARY';
+                continue;
+            }
+            
+            if( $currStatus === 'GLOBAL' ){
+                if( preg_match('/^Workerman version:(\S+)\s+PHP version:(\S+)/', $line, $matches ) &&
+                        array_key_exists(1,$matches) && array_key_exists(2,$matches) ){
+                    $arr[$gsKey]['Versions'] = ['Workerman' => $matches[1], 'PHP' => $matches[2]];
+                } elseif( preg_match('/^start time:(.*?)\s+run(.*)/', $line, $matches ) &&
+                        array_key_exists(1,$matches) && array_key_exists(2,$matches) ){
+                    $arr[$gsKey]['Run Stats'] = [ 'Start Time' => rtrim($matches[1]),
+                        'Uptime' => trim($matches[2]) ];
+                } elseif( preg_match('/^load average:\s(\S+,\s\S+,\s\S+)\s+event-loop:(\S+)/', $line, $matches ) &&
+                        array_key_exists(1,$matches) && array_key_exists(2,$matches) ){
+                    $arr[$gsKey]['Load Average'] = $matches[1];
+                    $arr[$gsKey]['Event'] = $matches[2];
+                } elseif( preg_match('/^(\d+) workers\s+(\d+) processes/', $line, $matches ) &&
+                        array_key_exists(1,$matches) && array_key_exists(2,$matches) ){
+                    $arr[$gsKey]['Workers'] = [ 'Count' => $matches[1], 'Processes' => $matches[2],
+                        'Records' => [] ];
+                    $arr[$pKey]['Count'] = $matches[2];
+                }
+            } elseif( $currStatus === 'WORKER' ){
+                
+                if( preg_match('/^(.*?)\s(\d)\s+(\d)/', $line, $matches ) &&
+                        array_key_exists(1,$matches) && array_key_exists(2,$matches) && array_key_exists(3,$matches) ){
+
+                    $arr[$gsKey]['Workers']['Records'][] = ['Name' => rtrim($matches[1]), 
+                                                                    'Exit Status' => intval($matches[2]),
+                                                                    'Exit Count' => intval($matches[3])];
+                }
+            } elseif( $currStatus === 'PROCESS' ){
+                if(preg_match('/^pid\s+memory\s+listening/', $line)) {
+                    preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(.*)/', 
+                          $line, 
+                          $matches );
+                
+                    if( count($matches) < 3 ){
+                        continue;
+                    }
+                    
+                    for($i = 1; $i < count($matches); $i++ ){
+                        $processKeys[$i] = $matches[$i];
+                    }
+                    
+                } elseif( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/', 
+                          $line, 
+                          $matches ) ){
+                    
+                    if( count($processKeys) !== count($matches) - 1  || count($processKeys) < 3 ){
+                        //header row column count did not match row count
+                        continue;
+                    }
+                    $pArr = [];
+                    
+                    for( $i = 1; $i <= count($processKeys); $i++ ){
+                        $pArr[$processKeys[$i]] = ( is_numeric($matches[$i]) ? intval($matches[$i]) : $matches[$i] );
+                    }
+                    $arr[$pKey]['Records'][] = $pArr;  
+                }
+
+            } elseif( $currStatus === 'SUMMARY') {
+                if( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/', 
+                          $line, 
+                          $matches ) ){
+                
+                    if( count($processKeys) !== count($matches) - 1 || count($processKeys) < 3 ){
+                        //header row column count did not match row count
+                        continue;
+                    }
+                    
+                    $pArr = [];
+                    
+                    for( $i = 2; $i < count($processKeys); $i++ ){
+                        if( $matches[$i] === '-' ){
+                            continue;
+                        }
+                        $pArr[$processKeys[$i]] = ( is_numeric($matches[$i]) ? intval($matches[$i]) : $matches[$i] );
+                    }
+        
+                    $arr[$pKey]['Summary'] = $pArr;  
+                }
+            }
+        }
+
+        return json_encode($arr, JSON_PRETTY_PRINT);
+        
+    }    
+    
     protected static function formatConnectionStatusData(): string
     {
         return file_get_contents(static::$connectionsFile);

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1295,7 +1295,7 @@ class Worker
                     }
 
                 } elseif( preg_match('/^(.*?)\s+(.*?)\s+(.*?)\s+(.*?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*)/',
-                          $line, 
+                          $line,
                           $matches ) ){
 
                     if( count($processKeys) !== count($matches) - 1  || count($processKeys) < 3 ){
@@ -1329,7 +1329,7 @@ class Worker
                         $pArr[$processKeys[$i]] = ( is_numeric($matches[$i]) ? intval($matches[$i]) : $matches[$i] );
                     }
 
-                    $arr[$pKey]['Summary'] = $pArr;  
+                    $arr[$pKey]['Summary'] = $pArr;
                 }
             }
         }


### PR DESCRIPTION
Added new -jl flag, that only does something for the status call.  When called, existing formatProcessStatusData evaluates boolean flag.  If the flag is set, then call new formatConnectionStatusDataJson to turn formatted output into JSON.