### PR TITLE
Update tests version libs to fix warnings and deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --ansi
 
       - name: Static analysis
         run: composer analyze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           coverage: xdebug
 
       - name: Install dependencies
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "require-dev": {
         "pestphp/pest": "2.x-dev",
-        "mockery/mockery": "2.0.x-dev",
+        "mockery/mockery": "^1.6",
         "guzzlehttp/guzzle": "^7.0",
         "phpstan/phpstan": "1.11.x-dev"
     },


### PR DESCRIPTION
v1.6.x work OK with PHP 8.4 (without deprecations)

And add ansi color output to composer in the workflow.

Updated workflow actions.