### PR TITLE
检测是否为null

### DIFF
--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -610,7 +610,9 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
      */
     public function pauseRecv(): void
     {
-        $this->eventLoop->offReadable($this->socket);
+        if($this->eventLoop !== null){
+            $this->eventLoop->offReadable($this->socket);
+        }
         $this->isPaused = true;
     }
 
@@ -1037,10 +1039,12 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
             return;
         }
         // Remove event listener.
-        $this->eventLoop->offReadable($this->socket);
-        $this->eventLoop->offWritable($this->socket);
-        if (DIRECTORY_SEPARATOR === '\\' && method_exists($this->eventLoop, 'offExcept')) {
-            $this->eventLoop->offExcept($this->socket);
+        if($this->eventLoop !== null){
+            $this->eventLoop->offReadable($this->socket);
+            $this->eventLoop->offWritable($this->socket);
+            if (DIRECTORY_SEPARATOR === '\\' && method_exists($this->eventLoop, 'offExcept')) {
+                $this->eventLoop->offExcept($this->socket);
+            }
         }
 
         // Close socket.


### PR DESCRIPTION
在进程结束的时候可能会出现"Call to a member function offReadable() on null"错误