### PR TITLE
Remove HHVM compatibility code

### DIFF
--- a/src/Connection/AsyncTcpConnection.php
+++ b/src/Connection/AsyncTcpConnection.php
@@ -381,10 +381,7 @@ class AsyncTcpConnection extends TcpConnection
             }
             // Nonblocking.
             stream_set_blocking($this->socket, false);
-            // Compatible with hhvm
-            if (function_exists('stream_set_read_buffer')) {
-                stream_set_read_buffer($this->socket, 0);
-            }
+            stream_set_read_buffer($this->socket, 0);
             // Try to open keepalive for tcp and disable Nagle algorithm.
             if (function_exists('socket_import_stream') && $this->transport === 'tcp') {
                 $socket = socket_import_stream($this->socket);

--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -382,10 +382,7 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
         }
         $this->socket = $socket;
         stream_set_blocking($this->socket, false);
-        // Compatible with hhvm
-        if (function_exists('stream_set_read_buffer')) {
-            stream_set_read_buffer($this->socket, 0);
-        }
+        stream_set_read_buffer($this->socket, 0);
         $this->eventLoop = $eventLoop;
         $this->eventLoop->onReadable($this->socket, $this->baseRead(...));
         $this->maxSendBufferSize = self::$defaultMaxSendBufferSize;


### PR DESCRIPTION
Since HHVM no longer supports PHP and the dependencies have been updated.