### PR TITLE
Remove gc_collect_cycles() and gc_mem_caches() from writeStatisticsToStatusFile()

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2180,9 +2180,6 @@ class Worker
             return;
         }
 
-        // For child processes.
-        gc_collect_cycles();
-        gc_mem_caches();
         reset(static::$workers);
         /** @var static $worker */
         $worker = current(static::$workers);


### PR DESCRIPTION
Title: Remove gc_collect_cycles() and gc_mem_caches() from writeStatisticsToStatusFile()

Description:

🛠️ What does this PR do?

This PR removes the calls to gc_collect_cycles() and gc_mem_caches() in the writeStatisticsToStatusFile() method.

📌 Why is this change needed?

When using pcntl_fork(), PHP relies on the Copy-on-Write (CoW) mechanism to share memory between the master process and worker processes. Calling garbage collection (GC) methods in child processes can cause the following issues:

Increased Memory Usage:
Triggering gc_collect_cycles() or gc_mem_caches() forces PHP to examine and potentially free memory that is shared via CoW. This breaks the shared memory model and results in unnecessary memory duplication, increasing the overall memory footprint.

Performance Degradation:
Frequent garbage collection cycles can negatively impact performance by adding overhead to memory management, especially in high-throughput environments.

Given that PHP's garbage collection works automatically under normal circumstances, explicitly forcing collection is unnecessary and counterproductive in forked environments.

✅ How does this change benefit the project?

Reduced Memory Usage: Prevents unnecessary memory duplication in forked processes.

Improved Performance: Avoids the overhead of unnecessary garbage collection.

Consistency: Aligns with best practices for managing memory in multi-process environments.

🔍 Testing & Compatibility

This change has been tested in a forked process environment and verified to reduce memory bloat without affecting the accuracy of worker statistics.

No breaking changes are introduced with this PR.

![Screenshot 2025-03-26 at 3 28 03 PM](https://github.com/user-attachments/assets/65143d91-13fd-48cc-b83d-483d6d4cd752)