### PR TITLE
Improved onWebSocketClose with response message.

### DIFF
--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -133,18 +133,25 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
     public $onConnect = null;
 
     /**
-     * Emitted before websocket handshake (Only works when protocol is ws).
+     * Emitted before websocket handshake (Only called when protocol is ws).
      *
      * @var ?callable
      */
     public $onWebSocketConnect = null;
 
     /**
-     * Emitted after websocket handshake (Only works when protocol is ws).
+     * Emitted after websocket handshake (Only called when protocol is ws).
      *
      * @var ?callable
      */
     public $onWebSocketConnected = null;
+
+    /**
+     * Emitted when websocket connection is closed (Only called when protocol is ws).
+     *
+     * @var ?callable
+     */
+    public $onWebSocketClose = null;
 
     /**
      * Emitted when data is received.

--- a/src/Protocols/Ws.php
+++ b/src/Protocols/Ws.php
@@ -116,7 +116,7 @@ class Ws
                     // Try to emit onWebSocketClose callback.
                     if (isset($connection->onWebSocketClose)) {
                         try {
-                            ($connection->onWebSocketClose)($connection);
+                            ($connection->onWebSocketClose)($connection, self::decode($buffer, $connection));
                         } catch (Throwable $e) {
                             Worker::stopAll(250, $e);
                         }


### PR DESCRIPTION
WebSocket server can send back status code with message indicating why the close was done. Added new parameter to handle the case.