### PR TITLE
Fix typo change Jit for JIT [ci skip]

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1009,7 +1009,7 @@ class Worker
         //Show version
         $jitStatus = function_exists('opcache_get_status') && (opcache_get_status()['jit']['on'] ?? false) === true ? 'on' : 'off';
         $version = str_pad('Workerman/' . static::VERSION, 24);
-        $version .= str_pad('PHP/' . PHP_VERSION . ' (Jit ' . $jitStatus . ')', 30);
+        $version .= str_pad('PHP/' . PHP_VERSION . ' (JIT ' . $jitStatus . ')', 30);
         $version .= php_uname('s') . '/' . php_uname('r') . PHP_EOL;
         return $version;
     }


### PR DESCRIPTION
The correct acronim is JIT.
And it's a very good addition this information.

In the Techempower benchmark we are not using JIT in all Adapterman permutations.