### PR TITLE
[fix] worker with id 0 looses pid

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1884,7 +1884,9 @@ class Worker
 
                         // Mark id is available.
                         $id = static::getId($workerId, $pid);
-                        static::$idMap[$workerId][$id] = 0;
+                        if ($id !== false) {
+                            static::$idMap[$workerId][$id] = 0;
+                        }
 
                         break;
                     }


### PR DESCRIPTION
found in #1114 

When scale down worker count and child is killed `getId` method returns false. `$_idMap[false] = 0` is called and replaces `$_idMap[0]` value with 0