### PR TITLE
修复 Windows 环境下 socket 绑定失败问题（Swow1.6.0）

### DIFF
--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -886,19 +886,10 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
      */
     public function pipe(self $dest): void
     {
-        $source = $this;
-        $this->onMessage = function ($source, $data) use ($dest) {
-            $dest->send($data);
-        };
-        $this->onClose = function () use ($dest) {
-            $dest->close();
-        };
-        $dest->onBufferFull = function () use ($source) {
-            $source->pauseRecv();
-        };
-        $dest->onBufferDrain = function () use ($source) {
-            $source->resumeRecv();
-        };
+        $this->onMessage = fn ($source, $data) => $dest->send($data);
+        $this->onClose = fn () => $dest->close();
+        $dest->onBufferFull = fn () => $this->pauseRecv();
+        $dest->onBufferDrain = fn() => $this->resumeRecv();
     }
 
     /**

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2449,7 +2449,7 @@ class Worker
             $errNo = 0;
             $errMsg = '';
             // SO_REUSEPORT.
-            if ($this->reusePort) {
+            if ($this->reusePort && DIRECTORY_SEPARATOR !== '\\') {
                 stream_context_set_option($this->socketContext, 'socket', 'so_reuseport', 1);
             }
 


### PR DESCRIPTION
```
Warning: [Warning in main] stream_socket_server(): Unable to connect to tcp://0.0.0.0:8792 (Socket bind failed, reason: Operation not supported on socket)
Stack trace:
#0 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(2402): stream_socket_server('tcp://0.0.0.0:8...', 0, '', 12, Resource id #211)
#1 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(1611): Workerman\Worker->listen()
#2 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(1528): Workerman\Worker::forkWorkersForWindows()
#3 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(594): Workerman\Worker::forkWorkers()
#4 E:\workerman\api-v3\runtime\windows\start_apiv3.php(33): Workerman\Worker::runAll()
#5 {main}
  triggered in E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php on line 2402
RuntimeException: Socket bind failed, reason: Operation not supported on socket in E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php:2404
Stack trace:
#0 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(1611): Workerman\Worker->listen()
#1 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(1528): Workerman\Worker::forkWorkersForWindows()
#2 E:\workerman\api-v3\vendor\workerman\workerman\src\Worker.php(594): Workerman\Worker::forkWorkers()
#3 E:\workerman\api-v3\runtime\windows\start_apiv3.php(33): Workerman\Worker::runAll()
#4 {main}
```