### PR TITLE
fix custom protocols in Worker::$logFile

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -750,7 +750,7 @@ class Worker
         // Log file.
         static::$logFile = static::$logFile ?: sprintf('%s/workerman.log', $startFileDir);
 
-        if (static::$logFile !== '/dev/null' && !is_file(static::$logFile)) {
+        if (static::$logFile !== '/dev/null' && !is_file(static::$logFile) && !str_contains(static::$logFile, '://')) {
             // if /runtime/logs  default folder not exists
             if (!is_dir(dirname(static::$logFile))) {
                 mkdir(dirname(static::$logFile), 0777, true);


### PR DESCRIPTION
skip invalid directory creation and permission changes for Worker::$logFile when custom protocol handlers are used (like php://stdout)