### PR TITLE
Refactor WebSocket handshake error handling

### DIFF
--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -108,7 +108,7 @@ class Websocket
             }
         } else {
             $firstByte = ord($buffer[0]);
-            $secondByte = ord($buffer[1]);
+            $secondByte = ord($buffer[1]);Sec-WebSocket-Version
             $dataLen = $secondByte & 127;
             $isFinFrame = $firstByte >> 7;
             $masked = $secondByte >> 7;
@@ -373,11 +373,12 @@ class Websocket
      */
     public static function dealHandshake(string $buffer, TcpConnection $connection): int
     {
+        $_400 = "HTTP/1.1 400 Bad Request\r\n\r\n<div style=\"text-align:center\"><h1>400 Bad Request</h1><hr>workerman</div>";
+        
         // HTTP protocol.
         if (!str_starts_with($buffer, 'GET')) {
             // Bad websocket handshake request.
-            $connection->close(
-                "HTTP/1.1 400 Bad Request\r\n\r\n<div style=\"text-align:center\"><h1>400 Bad Request</h1><hr>workerman</div>", true);
+            $connection->close($_400, true);
             return 0;
         }
 
@@ -388,12 +389,27 @@ class Websocket
         }
         $headerLength = $headerEndPos + 4;
 
+        // Check WebSocket version - RFC 6455 Section 4.4
+        if (preg_match("/Sec-WebSocket-Version: *(.*?)\r\n/i", $buffer, $match)) {
+            if($match[1] !== '13') {
+                $_426 = "HTTP/1.1 426 Upgrade Required\r\n"
+                    . "Connection: Upgrade\r\n"
+                    . "Upgrade: WebSocket\r\n"
+                    . "Sec-WebSocket-Version: 13\r\n\r\n";
+                
+                $connection->close($_426, true);
+                return 0;
+             }
+        } else {
+            $connection->close($_400, true);
+            return 0;
+        }
+        
         // Get Sec-WebSocket-Key.
         if (preg_match("/Sec-WebSocket-Key: *(.*?)\r\n/i", $buffer, $match)) {
             $SecWebSocketKey = $match[1];
         } else {
-            $connection->close(
-                "HTTP/1.1 400 Bad Request\r\n\r\n<div style=\"text-align:center\"><h1>WebSocket</h1><hr>workerman</div>", true);
+            $connection->close($_400, true);
             return 0;
         }
         // Calculation websocket key.

--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -373,12 +373,12 @@ class Websocket
      */
     public static function dealHandshake(string $buffer, TcpConnection $connection): int
     {
-        $_400 = "HTTP/1.1 400 Bad Request\r\n\r\n<div style=\"text-align:center\"><h1>400 Bad Request</h1><hr>workerman</div>";
+        $HTTP_400 = "HTTP/1.1 400 Bad Request\r\n\r\n<div style=\"text-align:center\"><h1>400 Bad Request</h1><hr>workerman</div>";
         
         // HTTP protocol.
         if (!str_starts_with($buffer, 'GET')) {
             // Bad websocket handshake request.
-            $connection->close($_400, true);
+            $connection->close($HTTP_400, true);
             return 0;
         }
 
@@ -410,7 +410,7 @@ class Websocket
         if (preg_match("/Sec-WebSocket-Key: *(.*?)\r\n/i", $buffer, $match)) {
             $SecWebSocketKey = $match[1];
         } else {
-            $connection->close($_400, true);
+            $connection->close($HTTP_400, true);
             return 0;
         }
         // Calculation websocket key.

--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -108,7 +108,7 @@ class Websocket
             }
         } else {
             $firstByte = ord($buffer[0]);
-            $secondByte = ord($buffer[1]);Sec-WebSocket-Version
+            $secondByte = ord($buffer[1]);
             $dataLen = $secondByte & 127;
             $isFinFrame = $firstByte >> 7;
             $masked = $secondByte >> 7;

--- a/src/Protocols/Websocket.php
+++ b/src/Protocols/Websocket.php
@@ -401,7 +401,8 @@ class Websocket
                 return 0;
              }
         } else {
-            $connection->close($_400, true);
+            $connection->close(
+                "HTTP/1.1 400 Bad Request\r\nSec-WebSocket-Version: 13\r\n\r\n", true);
             return 0;
         }
         


### PR DESCRIPTION
Add error 426 if websocket version is incorrect or 400 if don't exist (RFC 6455 [Section 4.4](https://www.rfc-editor.org/rfc/rfc6455#section-4.4)  and [section-4.2.2](https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.2) ).

Do you want than we create a test ?  Because we have the test of Http11probe.
