### PR TITLE
Missing Host header causes 400 Bad Request for HTTP/1.1

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -131,6 +131,8 @@ class Http
         //       Use [ \t]* instead of \s* to avoid matching across lines.
         //       The pattern uses case-insensitive modifier (~i) for header name matching.
         $headerValidatePattern = '~\A'
+            // Missing the host header and value for HTTP/1.1 requests (case-insensitive; line-start must be "\r\n" to avoid matching "x-Host").
+            . '(?![\s\S]*\r\nHost[ \t]*:[ \t]*[^\r]+)'
             // Optional: capture Content-Length value (must be at \A to scan entire header)
             . '(?:(?=[\s\S]*\r\nContent-Length[ \t]*:[ \t]*(\d+)[ \t]*\r\n))?'
             // Disallow Transfer-Encoding header

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -131,8 +131,8 @@ class Http
         //       Use [ \t]* instead of \s* to avoid matching across lines.
         //       The pattern uses case-insensitive modifier (~i) for header name matching.
         $headerValidatePattern = '~\A'
-            // Missing the host header and value for HTTP/1.1 requests (case-insensitive; line-start must be "\r\n" to avoid matching "x-Host").
-            . '(?![\s\S]*\r\nHost[ \t]*:[ \t]*[^\r]+)'
+            // Missing the host header or value for HTTP/1.1 requests (case-insensitive; line-start must be "\r\n" to avoid matching "x-Host").
+            . '(?:(?=[\s\S]*\r\nHost[ \t]*:[ \t]*(?:[^\r\n]+)?\r\n))?'
             // Optional: capture Content-Length value (must be at \A to scan entire header)
             . '(?:(?=[\s\S]*\r\nContent-Length[ \t]*:[ \t]*(\d+)[ \t]*\r\n))?'
             // Disallow Transfer-Encoding header

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -5,6 +5,8 @@ use Workerman\Protocols\Http;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
 
+const HTTP_400 = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+
 it('customizes request class', function () {
     //backup old request class
     $oldRequestClass = Http::requestClass();
@@ -53,7 +55,7 @@ it('missing Host header causes 400 Bad Request for HTTP/1.1', function () {
     $tcpConnection = Mockery::spy(TcpConnection::class);
     expect(Http::input("GET / HTTP/1.1\r\n\r\n", $tcpConnection))->toBe(0);
     $tcpConnection->shouldHaveReceived('end', function ($actual) {
-        return str_starts_with($actual, '400 Bad Request') && str_contains($actual, "Connection: close\r\n");
+        return str_contains($actual, '400 Bad Request') && str_contains($actual, "Connection: close\r\n");
     });
 });
 

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -48,6 +48,15 @@ it('tests ::input', function () {
     }, '413 Payload Too Large');
 });
 
+it('missing Host header causes 400 Bad Request for HTTP/1.1', function () {
+    /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
+    $tcpConnection = Mockery::spy(TcpConnection::class);
+    expect(Http::input("GET / HTTP/1.1\r\n\r\n", $tcpConnection))->toBe(0);
+    $tcpConnection->shouldHaveReceived('end', function ($actual) {
+        return str_starts_with($actual, '400 Bad Request') && str_contains($actual, "Connection: close\r\n");
+    });
+});
+
 it('sends 413 with Connection: close when header end is missing and buffered length reaches at least 16384 bytes', function (int $incompleteLength) {
     /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
     $tcpConnection = Mockery::spy(TcpConnection::class);


### PR DESCRIPTION
[rfc7230 section-5.4](https://www.rfc-editor.org/rfc/rfc7230#section-5.4)
First we create the test and add the code.

Later we need to update the tests.