### PR TITLE
Remove Content-Length header from HTTP 400 and 413 responses

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -65,14 +65,14 @@ class Http
      *
      * @var string
      */
-    protected const HTTP_400 = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+    protected const HTTP_400 = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
 
     /**
      * Payload too large.
      *
      * @var string
      */
-    protected const HTTP_413 = "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+    protected const HTTP_413 = "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n";
 
     /**
      * Get or set the request class name.


### PR DESCRIPTION
The `Content-Length` field is optional in HTTP responses when the server closes the connection immediately after sending the headers.

PD: we can also maintain it, but we send extra bytes for nothing.