### PR TITLE
Update HTTP request validation to disallow lowercase methods and versions

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,7 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '(?:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +\/[^\x00-\x20\x7f]* +HTTP\/1\.[01]\r\n~i';
+            . '(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +\/[^\x00-\x20\x7f]* +(?-i:HTTP)\/1\.[01]\r\n~i';
 
         if (!preg_match($headerValidatePattern, $header, $matches)) {
             if (preg_match('~\r\nTransfer-Encoding[ \t]*:~i', $header)) {

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,7 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +\/[^\x00-\x20\x7f]* +(?-i:HTTP)\/1\.[01]\r\n~i';
+            . '(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +/[^\x00-\x20\x7f]* +(?-i:HTTP)/1.[01]\r\n~i';
 
         if (!preg_match($headerValidatePattern, $header, $matches)) {
             if (preg_match('~\r\nTransfer-Encoding[ \t]*:~i', $header)) {

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,7 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '((?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH)[ \t])+(/[^\x00-\x20\x7f]*)+([ \t](?-i:HTTP)/1.[01])\r\n'
+            . '(?:(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH)[ \t])+(?:/[^\x00-\x20\x7f]*)+(?:[ \t](?-i:HTTP)/1.[01])\r\n'
             // Flag case-insensitive
             . '~i';
 

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,7 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '(?:(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) )+(?:/[^\x00-\x20\x7f]*)+(?: (?-i:HTTP)/1.[01])\r\n'
+            . '(?:(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) )+(?:/[^\x00-\x20\x7f]*)+(?: (?-i:HTTP)/1.[0-9])\r\n'
             // Flag case-insensitive
             . '~i';
 

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,7 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '(?:(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH)[ \t])+(?:/[^\x00-\x20\x7f]*)+(?:[ \t](?-i:HTTP)/1.[01])\r\n'
+            . '(?:(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) )+(?:/[^\x00-\x20\x7f]*)+(?: (?-i:HTTP)/1.[01])\r\n'
             // Flag case-insensitive
             . '~i';
 

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,9 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +/[^\x00-\x20\x7f]* +(?-i:HTTP)/1.[01]\r\n~i';
+            . '(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +/[^\x00-\x20\x7f]* +(?-i:HTTP)/1.[01]\r\n'
+            // Flag case-insensitive
+            . '~i';
 
         if (!preg_match($headerValidatePattern, $header, $matches)) {
             if (preg_match('~\r\nTransfer-Encoding[ \t]*:~i', $header)) {

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -140,7 +140,7 @@ class Http
             // Disallow duplicate Content-Length headers (adjacent or separated)
             . '(?![\s\S]*\r\nContent-Length[ \t]*:[^\r\n]*\r\n(?:[\s\S]*?\r\n)?Content-Length[ \t]*:)'
             // Match request line: METHOD SP request-target SP HTTP-version CRLF
-            . '(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) +/[^\x00-\x20\x7f]* +(?-i:HTTP)/1.[01]\r\n'
+            . '((?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH)[ \t])+(/[^\x00-\x20\x7f]*)+([ \t](?-i:HTTP)/1.[01])\r\n'
             // Flag case-insensitive
             . '~i';
 

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -120,6 +120,10 @@ it('tests ::input request-line and header validation matrix', function (string $
         "GET / HTTP/1.1\r\nX-Transfer-Encoding: chunked\r\n\r\n",
         18 + strlen("X-Transfer-Encoding: chunked\r\n"),
     ],
+    'allow minor version in HTTP/1.1' => [
+        "GET / HTTP/1.2\r\n\r\n",
+        18, // strlen("GET / HTTP/1.2\r\n\r\n")
+    ],
 ]);
 
 it('rejects invalid request-line cases in ::input', function (string $buffer) {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -160,6 +160,18 @@ it('rejects invalid request-line cases in ::input', function (string $buffer) {
     'lowercase version is not allowed' => [
         "GET / http/1.1\r\n\r\n",
     ],
+    'leading OWS is not allowed' => [
+        " GET / http/1.1\r\n\r\n",
+    ],
+    'only 1 OWS after method is allowed' => [
+        "GET  / http/1.1\r\n\r\n",
+    ],
+    'only 1 OWS after path is allowed' => [
+        "GET /  http/1.1\r\n\r\n",
+    ],
+    'OWS after version is not allowed' => [
+        "GET / http/1.1 \r\n\r\n",
+    ],
 
 ]);
 

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -154,9 +154,13 @@ it('rejects invalid request-line cases in ::input', function (string $buffer) {
     'CRLF injection attempt in request-target' => [
         "GET /foo\r\nX: y HTTP/1.1\r\n\r\n",
     ],
-    'lowercase method and version is not allowed' => [
-        "get / http/1.1\r\n\r\n",
+    'lowercase method is not allowed' => [
+        "get / HTTP/1.1\r\n\r\n",
     ],
+    'lowercase version is not allowed' => [
+        "GET / http/1.1\r\n\r\n",
+    ],
+
 ]);
 
 it('rejects Transfer-Encoding and bad/duplicate Content-Length in ::input', function (string $buffer, ?string $expectedCloseContains = '400 Bad Request') {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -100,10 +100,6 @@ it('tests ::input request-line and header validation matrix', function (string $
         "GET / HTTP/1.1\r\n\r\n",
         18, // strlen("GET / HTTP/1.1\r\n\r\n")
     ],
-    'lowercase method and version is allowed' => [
-        "get / http/1.1\r\n\r\n",
-        18,
-    ],
     'all supported methods' => [
         "PATCH /a HTTP/1.0\r\n\r\n",
         21, // PATCH(5) + space + /a(2) + space + HTTP/1.0(8) + \r\n\r\n(4) = 21
@@ -157,6 +153,9 @@ it('rejects invalid request-line cases in ::input', function (string $buffer) {
     ],
     'CRLF injection attempt in request-target' => [
         "GET /foo\r\nX: y HTTP/1.1\r\n\r\n",
+    ],
+    'lowercase method and version is not allowed' => [
+        "get / http/1.1\r\n\r\n",
     ],
 ]);
 

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -160,16 +160,16 @@ it('rejects invalid request-line cases in ::input', function (string $buffer) {
     'lowercase version is not allowed' => [
         "GET / http/1.1\r\n\r\n",
     ],
-    'leading OWS is not allowed' => [
+    'leading spaces are not allowed' => [
         " GET / http/1.1\r\n\r\n",
     ],
-    'only 1 OWS after method is allowed' => [
+    'only 1 space after method is allowed' => [
         "GET  / http/1.1\r\n\r\n",
     ],
-    'only 1 OWS after path is allowed' => [
+    'only 1 space after path is allowed' => [
         "GET /  http/1.1\r\n\r\n",
     ],
-    'OWS after version is not allowed' => [
+    'space after version is not allowed' => [
         "GET / http/1.1 \r\n\r\n",
     ],
 


### PR DESCRIPTION
Method names are case-sensitive, and all registered methods are all upper-case.

The version of an HTTP/1.x message is indicated by an HTTP-version field in the [start-line](https://www.rfc-editor.org/rfc/rfc9112#message.format). HTTP-version is case-sensitive.

https://www.rfc-editor.org/rfc/rfc7231#section-4.1

And:
- Don't allow more than 1 space in the request line.
`Request-Line = Method SP Request-URI SP HTTP-Version`
https://www.rfc-editor.org/rfc/rfc9112#section-3

- Allow minor version HTTP (1.2 - 1.9) (this one is optional)
  A request using HTTP version 1.2, which does not exist but has a higher minor version than 1.1.
  https://www.rfc-editor.org/rfc/rfc9112#section-2.3

Changed and added tests.

PD: I think that we can create a request-line preg-match and another for the headers, theoretically will be faster and easier. We need to add full url or only path to req-line.