### PR TITLE
Update encode method to use type hinting for string|Response object

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Static analysis
         #continue-on-error: true
-        run: composer analyze
+        #run: composer analyze
 
       - name: Execute tests
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-lowest --prefer-dist --no-interaction --no-progress --ansi
 
       - name: Static analysis
-        #continue-on-error: true
-        #run: composer analyze
+        continue-on-error: true
+        run: composer analyze
 
       - name: Execute tests
         run: composer test

--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -460,7 +460,7 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
         // Try to call protocol::encode($sendBuffer) before sending.
         if (false === $raw && $this->protocol !== null) {
             try {
-                $sendBuffer = $this->protocol::encode($sendBuffer, $this);
+                $sendBuffer = $this->protocol::encode($sendBuffer, $this) ?? '';
             } catch(Throwable $e) {
                 $this->error($e);
             }

--- a/src/Connection/TcpConnection.php
+++ b/src/Connection/TcpConnection.php
@@ -457,10 +457,13 @@ class TcpConnection extends ConnectionInterface implements JsonSerializable
             return false;
         }
 
+        // Fix null to empty string.
+        $sendBuffer ??= '';
+
         // Try to call protocol::encode($sendBuffer) before sending.
         if (false === $raw && $this->protocol !== null) {
             try {
-                $sendBuffer = $this->protocol::encode($sendBuffer, $this) ?? '';
+                $sendBuffer = $this->protocol::encode($sendBuffer, $this);
             } catch(Throwable $e) {
                 $this->error($e);
             }

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,6 +19,7 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
+use Workerman\Protocols\Http\ServerSentEvents;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;
@@ -346,11 +347,11 @@ class Http
     /**
      * Http encode.
      *
-     * @param string|Response $response
+     * @param string|Response|ServerSentEvents $response
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(string|Response $response, TcpConnection $connection): string
+    public static function encode(string|Response|ServerSentEvents $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,7 +19,6 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
-use Workerman\Protocols\Http\ServerSentEvents;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;
@@ -347,11 +346,11 @@ class Http
     /**
      * Http encode.
      *
-     * @param string|Response|ServerSentEvents $response
+     * @param string|Response $response
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(string|Response|ServerSentEvents $response, TcpConnection $connection): string
+    public static function encode(string|Response $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -350,7 +350,7 @@ class Http
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(mixed $response, TcpConnection $connection): string
+    public static function encode(string|Response $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,7 +19,6 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
-use Workerman\Protocols\Http\ServerSentEvents;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;
@@ -347,11 +346,11 @@ class Http
     /**
      * Http encode.
      *
-     * @param string|Response|ServerSentEvents $response
+     * @param string|Stringable $response
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(string|Response|ServerSentEvents $response, TcpConnection $connection): string
+    public static function encode(string|Stringable $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,6 +19,7 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
+use Stringable;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,6 +19,7 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
+use Workerman\Protocols\Http\ServerSentEvents;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;
@@ -346,7 +347,7 @@ class Http
     /**
      * Http encode.
      *
-     * @param string|Response $response
+     * @param string|Response|ServerSentEvents $response
      * @param TcpConnection $connection
      * @return string
      */

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,7 +19,6 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
-use Workerman\Protocols\Http\ServerSentEvents;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;
@@ -347,11 +346,11 @@ class Http
     /**
      * Http encode.
      *
-     * @param string|Response|ServerSentEvents $response
+     * @param string $response
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(string|Response|ServerSentEvents $response, TcpConnection $connection): string
+    public static function encode(string $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -353,7 +353,7 @@ class Http
      */
     public static function encode(string|Stringable $response, TcpConnection $connection): string
     {
-        if (!is_object($response)) {
+        if (is_string($response)) {
             $extHeader = '';
             $contentType = 'text/html;charset=utf-8';
             foreach ($connection->headers as $name => $value) {

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -19,6 +19,7 @@ namespace Workerman\Protocols;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
+use Workerman\Protocols\Http\ServerSentEvents;
 use function clearstatcache;
 use function ctype_xdigit;
 use function filesize;
@@ -346,11 +347,11 @@ class Http
     /**
      * Http encode.
      *
-     * @param string $response
+     * @param string|Response|ServerSentEvents $response
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(string $response, TcpConnection $connection): string
+    public static function encode(string|Response|ServerSentEvents $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -351,7 +351,7 @@ class Http
      * @param TcpConnection $connection
      * @return string
      */
-    public static function encode(string|Response $response, TcpConnection $connection): string
+    public static function encode(string|Response|ServerSentEvents $response, TcpConnection $connection): string
     {
         if (!is_object($response)) {
             $extHeader = '';

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,7 +43,7 @@ function something()
     // ..
 }
 
-function testWithConnectionClose(Closure $closure, ?string $dataContains = null, $connectionClass = TcpConnection::class): void
+function testWithConnectionClose(Closure $closure, string $dataContains = '', $connectionClass = TcpConnection::class): void
 {
     $tcpConnection = Mockery::spy($connectionClass);
     $closure($tcpConnection);
@@ -56,7 +56,7 @@ function testWithConnectionClose(Closure $closure, ?string $dataContains = null,
     }
 }
 
-function testWithConnectionEnd(Closure $closure, ?string $dataContains = null, $connectionClass = TcpConnection::class): void
+function testWithConnectionEnd(Closure $closure, string $dataContains = '', $connectionClass = TcpConnection::class): void
 {
     $tcpConnection = Mockery::spy($connectionClass);
     $closure($tcpConnection);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,7 +43,7 @@ function something()
     // ..
 }
 
-function testWithConnectionClose(Closure $closure, string $dataContains = '', $connectionClass = TcpConnection::class): void
+function testWithConnectionClose(Closure $closure, ?string $dataContains = null, $connectionClass = TcpConnection::class): void
 {
     $tcpConnection = Mockery::spy($connectionClass);
     $closure($tcpConnection);
@@ -56,7 +56,7 @@ function testWithConnectionClose(Closure $closure, string $dataContains = '', $c
     }
 }
 
-function testWithConnectionEnd(Closure $closure, string $dataContains = '', $connectionClass = TcpConnection::class): void
+function testWithConnectionEnd(Closure $closure, ?string $dataContains = null, $connectionClass = TcpConnection::class): void
 {
     $tcpConnection = Mockery::spy($connectionClass);
     $closure($tcpConnection);


### PR DESCRIPTION
Available from PHP 8.0.

EDIT: ~`string|Response|ServerSentEvents`~  `string|Stringable`
With only type hint `string`, any class that implements `stringable` can be passed, so we are not limiting the classes. And we can simplify the `send()` code as always is string. But for now it's OK.

PD: later we need to check the `TcpConnection::send()` why the `$sendBuffer` receive `null`. This variable now is `mixed` need to be limited to `string|Stringable`.
For now use a fast fix `$sendBuffer ??= '';`