### PR TITLE
Add getMimeType($ext) function in class Response

### DIFF
--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -56,7 +56,7 @@ class Response implements Stringable
     public ?array $file = null;
 
     /**
-     * Mine type map.
+     * Mime Type map.
      * @var array
      */
     protected static array $mimeTypeMap = [
@@ -341,6 +341,17 @@ class Response implements Stringable
     }
 
     /**
+     * Get Mime Type from extension.
+     *
+     * @param string $ext
+     * @return string
+     */
+    public function getMimeType(string $ext): string
+    {
+        return self::$mimeTypeMap[$ext] ?? 'application/octet-stream';
+    }
+
+    /**
      * Set status.
      *
      * @param int $code
@@ -496,15 +507,12 @@ class Response implements Stringable
         if ($baseName === '') {
             $baseName = 'unknown';
         }
+        $mime = $this->getMimeType($extension);
         if (!isset($headers['Content-Type'])) {
-            if (isset(self::$mimeTypeMap[$extension])) {
-                $head .= "Content-Type: " . self::$mimeTypeMap[$extension] . "\r\n";
-            } else {
-                $head .= "Content-Type: application/octet-stream\r\n";
-            }
+                $head .= "Content-Type: " . $mime . "\r\n";
         }
 
-        if (!isset($headers['Content-Disposition']) && !isset(self::$mimeTypeMap[$extension])) {
+        if (!isset($headers['Content-Disposition']) && $mime === 'application/octet-stream') {
             $head .= "Content-Disposition: attachment; filename=\"$baseName\"\r\n";
         }
 

--- a/src/Protocols/Http/Response.php
+++ b/src/Protocols/Http/Response.php
@@ -507,9 +507,10 @@ class Response implements Stringable
         if ($baseName === '') {
             $baseName = 'unknown';
         }
-        $mime = $this->getMimeType($extension);
+        $mime = '';
         if (!isset($headers['Content-Type'])) {
-                $head .= "Content-Type: " . $mime . "\r\n";
+            $mime = $this->getMimeType($extension);
+            $head .= "Content-Type: " . $mime . "\r\n";
         }
 
         if (!isset($headers['Content-Disposition']) && $mime === 'application/octet-stream') {

--- a/tests/Unit/Protocols/Http/ResponseTest.php
+++ b/tests/Unit/Protocols/Http/ResponseTest.php
@@ -46,7 +46,9 @@ it('tests file', function (){
     // as the implementation of headers is a different function for files.
     // or actually maybe the Response is the one should be rewritten to reuse?
     $response = new Response();
-    $tmpFile = sys_get_temp_dir().'test.jpg';
+    $tmpFile = tempnam(sys_get_temp_dir(), 'test');
+    rename($tmpFile, $tmpFile .'.jpg');
+    $tmpFile .= '.jpg';
     file_put_contents($tmpFile, 'hello, xiami');
     $response->withFile($tmpFile, 0, 12);
     expect((string)$response)

--- a/tests/Unit/Protocols/Http/ResponseTest.php
+++ b/tests/Unit/Protocols/Http/ResponseTest.php
@@ -46,7 +46,7 @@ it('tests file', function (){
     // as the implementation of headers is a different function for files.
     // or actually maybe the Response is the one should be rewritten to reuse?
     $response = new Response();
-    $tmpFile = tempnam(sys_get_temp_dir(), 'test.jpg');
+    $tmpFile = sys_get_temp_dir().'test.jpg';
     file_put_contents($tmpFile, 'hello, xiami');
     $response->withFile($tmpFile, 0, 12);
     expect((string)$response)

--- a/tests/Unit/Protocols/Http/ResponseTest.php
+++ b/tests/Unit/Protocols/Http/ResponseTest.php
@@ -46,9 +46,7 @@ it('tests file', function (){
     // as the implementation of headers is a different function for files.
     // or actually maybe the Response is the one should be rewritten to reuse?
     $response = new Response();
-    $tmpFile = tempnam(sys_get_temp_dir(), 'test');
-    rename($tmpFile, $tmpFile .'.jpg');
-    $tmpFile .= '.jpg';
+    $tmpFile = tempnam(sys_get_temp_dir(), 'test.jpg');
     file_put_contents($tmpFile, 'hello, xiami');
     $response->withFile($tmpFile, 0, 12);
     expect((string)$response)


### PR DESCRIPTION
I'm creating a static file class for Adapterman.
First I tried some code creating a `StaticPreCompressed` middleware for Webman (later I'll send it).
That check the `Accept-Encoding` to try to serve pre-compressed `.br` and `.gz` files first, and serve correct headers.

But always download the file, even with the `Content-Type` header, because the middleware add it, but we change the file to serve adding `.br` or `.gz`. And this code search for `.br` or `.gz` extension: 
`if (!isset($headers['Content-Disposition']) && !isset(self::$mimeTypeMap[$extension]))`

So I refactored the code, and added the method for not repeat the code in the middleware again.




