### PR TITLE
Add HTTP 431 status for request header fields too large

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -78,8 +78,16 @@ class Http
     protected const HTTP_413 = "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n";
 
     /**
+     * Request Header Fields Too Large.
+     *
+     * @var string
+     */
+    protected const HTTP_431 = "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n";
+    
+    /**
      * Max bytes buffered while waiting for end of headers, and max offset of "\r\n\r\n" (header block size limit).
      */
+    
     protected const MAX_HEADER_LENGTH = 16384;
 
     /**
@@ -110,14 +118,14 @@ class Http
         $crlfPos = strpos($buffer, "\r\n\r\n");
         if (false === $crlfPos) {
             if (strlen($buffer) >= static::MAX_HEADER_LENGTH) {
-                $connection->end(static::HTTP_413, true);
+                $connection->end(static::HTTP_431, true);
             }
             return 0;
         }
 
         $length = $crlfPos + 4;
         if ($crlfPos >= static::MAX_HEADER_LENGTH) {
-            $connection->end(static::HTTP_413, true);
+            $connection->end(static::HTTP_431, true);
             return 0;
         }
         $header = isset($buffer[$length]) ? substr($buffer, 0, $length) : $buffer;

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -22,11 +22,11 @@ it('customizes request class', function () {
 });
 
 it('tests ::input', function () {
-    //test 413 payload too large
+    //test 431 Request Header Fields Too Large or not headers
     testWithConnectionEnd(function (TcpConnection $tcpConnection) {
         expect(Http::input(str_repeat('jhdxr', 3333), $tcpConnection))
             ->toBe(0);
-    }, '413 Payload Too Large');
+    }, '431 Request Header Fields Too Large');
 
     //example request from ChatGPT :)
     $buffer = "POST /path/to/resource HTTP/1.1\r\n" .
@@ -206,12 +206,12 @@ describe('HTTP/1.0', function () {
     });
 });
 
-it('sends 413 with Connection: close when header end is missing and buffered length reaches at least 16384 bytes', function (int $incompleteLength) {
+it('sends 431 with Connection: close when header end is missing and buffered length reaches at least 16384 bytes', function (int $incompleteLength) {
     /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
     $tcpConnection = Mockery::spy(TcpConnection::class);
     Http::input(str_repeat('a', $incompleteLength), $tcpConnection);
     $tcpConnection->shouldHaveReceived('end', function ($actual) {
-        return str_contains($actual, '413 Payload Too Large') && str_contains($actual, "Connection: close\r\n");
+        return str_contains($actual, '431 Request Header Fields Too Large') && str_contains($actual, "Connection: close\r\n");
     });
 })->with([
     'exactly 16384' => [16384],
@@ -231,7 +231,7 @@ it('accepts completed headers when header data is just under 16384 bytes', funct
     $tcpConnection->shouldNotHaveReceived('end');
 });
 
-it('sends 413 when completed header data reaches 16384 bytes', function () {
+it('sends 431 when completed header data reaches 16384 bytes', function () {
     /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
     $tcpConnection = Mockery::spy(TcpConnection::class);
     $tcpConnection->maxPackageSize = 2 * 1024 * 1024;
@@ -242,7 +242,7 @@ it('sends 413 when completed header data reaches 16384 bytes', function () {
     expect(strpos($buffer, "\r\n\r\n"))->toBe(16384);
     expect(Http::input($buffer, $tcpConnection))->toBe(0);
     $tcpConnection->shouldHaveReceived('end', function ($actual) {
-        return str_contains($actual, '413 Payload Too Large');
+        return str_contains($actual, '431 Request Header Fields Too Large');
     });
 });
 


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6585#section-5