### PR TITLE
Fix regex for HTTP RFC 9112 §2.3

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -129,7 +129,7 @@ class Http
         // Validate request line: METHOD SP origin-form SP HTTP/1.x
         $firstLineEnd = strpos($header, "\r\n");
         if (!preg_match(
-            '~^(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) /[^\x00-\x20\x7f]* (?-i:HTTP)/1\.(?<minor>[01])$~',
+            '~^(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) /[^\x00-\x20\x7f]* (?-i:HTTP)/1\.(?<minor>[0-9])$~',
             substr($header, 0, $firstLineEnd),
             $matches
         )) {
@@ -155,7 +155,7 @@ class Http
 
         // Host: required for HTTP/1.1, must not be duplicated for any version (RFC 7230 §5.4)
         $hostCount = count($headers['host'] ?? []);
-        if ($hostCount > 1 || ($matches['minor'] === '1' && $hostCount === 0)) {
+        if ($hostCount > 1 || ($matches['minor'] > '0' && $hostCount === 0)) {
             $connection->end(static::HTTP_400, true);
             return 0;
         }


### PR DESCRIPTION
A request using HTTP version 1.2, which does not exist but has a higher minor version than 1.1.
https://www.rfc-editor.org/rfc/rfc9112#section-2.3