### PR TITLE
Validate Host header format in Http.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.36 || ^3 || ^4",
-        "mockery/mockery": "^1.6",
+        "mockery/mockery": "^1.6.10",
         "guzzlehttp/guzzle": "^7.10",
         "phpstan/phpstan": "^2.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.36 || ^3 || ^4",
-        "mockery/mockery": "^1.6.10",
+        "mockery/mockery": "^1.6.12",
         "guzzlehttp/guzzle": "^7.10",
         "phpstan/phpstan": "^2.1"
     },

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -160,7 +160,7 @@ class Http
             return 0;
         }
         // Host header grammar | Host = uri-host [ ‘:’ port ]” – RFC 9110 Section 7.2
-        if (isset($headers['host'])) {
+        if (isset($headers['host'][0])) {
             if(!preg_match('/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$/', $headers['host'][0])) {
                 $connection->end(static::HTTP_400, true);
                 return 0;

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -161,7 +161,7 @@ class Http
         }
         // Host header grammar | Host = uri-host [ ‘:’ port ]” – RFC 9110 Section 7.2
         if (isset($headers['host'])) {
-            if(!preg_match('/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$/', $headers['host'])) {
+            if(!preg_match('/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$/', $headers['host'][0])) {
                 $connection->end(static::HTTP_400, true);
                 return 0;
             }

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -160,7 +160,7 @@ class Http
             return 0;
         }
         // Host header grammar | Host = uri-host [ ‘:’ port ]” – RFC 9110 Section 7.2
-        if (isset($headers['host']) {
+        if (isset($headers['host'])) {
             if(!preg_match('/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$/', $headers['host'])) {
                 $connection->end(static::HTTP_400, true);
                 return 0;

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -159,6 +159,13 @@ class Http
             $connection->end(static::HTTP_400, true);
             return 0;
         }
+        // Host header grammar | Host = uri-host [ ‘:’ port ]” – RFC 9110 Section 7.2
+        if (isset($headers['host']) {
+            if(!preg_match('/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$/', $headers['host'])) {
+                $connection->end(static::HTTP_400, true);
+                return 0;
+            }
+        }
 
         // Transfer-Encoding: must be sole header with value "chunked", no Content-Length
         if (isset($headers['transfer-encoding'])) {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -133,6 +133,15 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         'HTTP/1.1 Host with invalid character' => [
             "GET / HTTP/1.1\r\nHost: local host\r\n\r\n",
         ],
+        'HTTP/1.1 Host with invalid character in port' => [
+            "GET / HTTP/1.1\r\nHost: localhost:80a\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with only port' => [
+            "GET / HTTP/1.1\r\nHost: :8080\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with two comma separated values' => [
+            "GET / HTTP/1.1\r\nHost: localhost:8080, other.example.com\r\n\r\n",
+        ]
     ]);
 
     it('rejects duplicate Transfer-Encoding header lines', function (string $buffer) {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -141,10 +141,19 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         ],
         'HTTP/1.1 Host with two comma separated values' => [
             "GET / HTTP/1.1\r\nHost: localhost:8080, other.example.com\r\n\r\n",
-        ]
+        ],
+        'HTTP/1.1 Host with multiple colons' => [
+            "GET / HTTP/1.1\r\nHost: localhost:8080:9090\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with 1.1' => [
+            "GET / HTTP/1.1\r\nHost: 1.1\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with 1.1.1' => [
+            "GET / HTTP/1.1\r\nHost: 1.1.1\r\n\r\n",
+        ],
     ]);
 
-    it('accepts valid Host header | uri-host [ : port ]” - RFC 9110 Section 7.2', function (string $buffer) {
+    it('accepts valid Host header uri-host[:port] RFC 9110 Section 7.2', function (string $buffer) {
         /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
         $tcpConnection = Mockery::spy(TcpConnection::class);
         expect(Http::input($buffer, $tcpConnection))->not->toBe(0);
@@ -162,10 +171,10 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         'HTTP/1.1 Host with www.example.com' => [
             "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
         ],
-        'HTTP/1.1 Host with example.com and port' => [
+        'HTTP/1.1 Host with example.com:8080' => [
             "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n",
         ],
-        'HTTP/1.1 Host with subdomain' => [
+        'HTTP/1.1 Host with subdomain.example.com' => [
             "GET / HTTP/1.1\r\nHost: subdomain.example.com\r\n\r\n",
         ],
         'HTTP/1.1 Host with 192.168.0.1' => [
@@ -177,10 +186,10 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         'HTTP/1.1 Host with 1.1.1.1:8080' => [
             "GET / HTTP/1.1\r\nHost: 1.1.1.1:8080\r\n\r\n",
         ],
-        'HTTP/1.1 Host with localhost and port 80' => [
+        'HTTP/1.1 Host with localhost:80' => [
             "GET / HTTP/1.1\r\nHost: localhost:80\r\n\r\n",
         ],
-        'HTTP/1.1 Host with localhost and port 65535' => [
+        'HTTP/1.1 Host with localhost:65535' => [
             "GET / HTTP/1.1\r\nHost: localhost:65535\r\n\r\n",
         ],
     ]);

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -145,12 +145,6 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         'HTTP/1.1 Host with multiple colons' => [
             "GET / HTTP/1.1\r\nHost: localhost:8080:9090\r\n\r\n",
         ],
-        'HTTP/1.1 Host with 1.1' => [
-            "GET / HTTP/1.1\r\nHost: 1.1\r\n\r\n",
-        ],
-        'HTTP/1.1 Host with 1.1.1' => [
-            "GET / HTTP/1.1\r\nHost: 1.1.1\r\n\r\n",
-        ],
     ]);
 
     it('accepts valid Host header uri-host[:port] RFC 9110 Section 7.2', function (string $buffer) {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -165,6 +165,9 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         'HTTP/1.1 Host with example.com and port' => [
             "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n",
         ],
+        'HTTP/1.1 Host with subdomain' => [
+            "GET / HTTP/1.1\r\nHost: subdomain.example.com\r\n\r\n",
+        ],
         'HTTP/1.1 Host with 192.168.0.1' => [
             "GET / HTTP/1.1\r\nHost: 192.168.0.1\r\n\r\n",
         ],

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -116,7 +116,31 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         ],
     ]);
 
-    it('rejects bad Host header | uri-host [ : port ]” - RFC 9110 Section 7.2', function (string $buffer) {
+    it('rejects duplicate Transfer-Encoding header lines', function (string $buffer) {
+        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
+            expect(Http::input($buffer, $tcpConnection))->toBe(0);
+        }, '400 Bad Request');
+    })->with([
+        'GET with two Transfer-Encoding: chunked' => [
+            "GET / HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n",
+        ],
+        'GET with Transfer-Encoding chunked then identity' => [
+            "GET / HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: identity\r\n\r\n",
+        ],
+    ]);
+
+    it('accepts valid token field-names with hyphen and underscore', function () {
+        /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
+        $tcpConnection = Mockery::spy(TcpConnection::class);
+        $tcpConnection->maxPackageSize = 1024 * 1024;
+        $buffer = "GET / HTTP/1.1\r\nHost: h\r\nX-Custom_Header: ok\r\n\r\n";
+        expect(Http::input($buffer, $tcpConnection))->toBe(strlen($buffer));
+        $tcpConnection->shouldNotHaveReceived('end');
+    });
+});
+
+describe('Host header', function () {
+    it('rejects bad Host header uri-host[:port] RFC 9110 Section 7.2', function (string $buffer) {
         testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
             expect(Http::input($buffer, $tcpConnection))->toBe(0);
         }, '400 Bad Request');
@@ -187,28 +211,6 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
             "GET / HTTP/1.1\r\nHost: localhost:65535\r\n\r\n",
         ],
     ]);
-
-    it('rejects duplicate Transfer-Encoding header lines', function (string $buffer) {
-        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
-            expect(Http::input($buffer, $tcpConnection))->toBe(0);
-        }, '400 Bad Request');
-    })->with([
-        'GET with two Transfer-Encoding: chunked' => [
-            "GET / HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n",
-        ],
-        'GET with Transfer-Encoding chunked then identity' => [
-            "GET / HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: identity\r\n\r\n",
-        ],
-    ]);
-
-    it('accepts valid token field-names with hyphen and underscore', function () {
-        /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
-        $tcpConnection = Mockery::spy(TcpConnection::class);
-        $tcpConnection->maxPackageSize = 1024 * 1024;
-        $buffer = "GET / HTTP/1.1\r\nHost: h\r\nX-Custom_Header: ok\r\n\r\n";
-        expect(Http::input($buffer, $tcpConnection))->toBe(strlen($buffer));
-        $tcpConnection->shouldNotHaveReceived('end');
-    });
 });
 
 describe('HTTP/1.0', function () {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -116,6 +116,25 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         ],
     ]);
 
+    it('rejects bad Host header | uri-host [ : port ]” - RFC 9110 Section 7.2', function (string $buffer) {
+        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
+            expect(Http::input($buffer, $tcpConnection))->toBe(0);
+        }, '400 Bad Request');
+    })->with([
+        'HTTP/1.1 Host empty' => [
+            "GET / HTTP/1.1\r\nHost: \r\nHost: b\r\n\r\n",
+        ],
+        'HTTP/1.0 Host with user info' => [
+            "GET / HTTP/1.0\r\nHost: user@localhost:8080\r\nHost: b\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with invalid port' => [
+            "GET / HTTP/1.1\r\nHost: localhost:abc\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with invalid character' => [
+            "GET / HTTP/1.1\r\nHost: local host\r\n\r\n",
+        ],
+    ]);
+
     it('rejects duplicate Transfer-Encoding header lines', function (string $buffer) {
         testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
             expect(Http::input($buffer, $tcpConnection))->toBe(0);

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -146,7 +146,7 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
 
     it('accepts valid Host header | uri-host [ : port ]” - RFC 9110 Section 7.2', function (string $buffer) {
         testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
-            expect(Http::input($buffer, $tcpConnection))->toBe(0);
+            expect(Http::input($buffer, $tcpConnection))->not->toBe(0);
         }, '200 OK');
     })->with([
         'HTTP/1.1 Host localhost' => [

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -145,9 +145,10 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
     ]);
 
     it('accepts valid Host header | uri-host [ : port ]” - RFC 9110 Section 7.2', function (string $buffer) {
-        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
-            expect(Http::input($buffer, $tcpConnection))->not->toBe(0);
-        }, '200 OK');
+        /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
+        $tcpConnection = Mockery::spy(TcpConnection::class);
+        expect(Http::input($buffer, $tcpConnection))->not->toBe(0);
+        $tcpConnection->shouldNotHaveReceived('close');
     })->with([
         'HTTP/1.1 Host localhost' => [
             "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -122,7 +122,7 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         }, '400 Bad Request');
     })->with([
         'HTTP/1.1 Host empty' => [
-            "GET / HTTP/1.1\r\nHost: \r\nHost: b\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost: \r\n\r\n",
         ],
         'HTTP/1.0 Host with user info' => [
             "GET / HTTP/1.0\r\nHost: user@localhost:8080\r\nHost: b\r\n\r\n",
@@ -142,6 +142,43 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
         'HTTP/1.1 Host with two comma separated values' => [
             "GET / HTTP/1.1\r\nHost: localhost:8080, other.example.com\r\n\r\n",
         ]
+    ]);
+
+    it('accepts valid Host header | uri-host [ : port ]” - RFC 9110 Section 7.2', function (string $buffer) {
+        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
+            expect(Http::input($buffer, $tcpConnection))->toBe(0);
+        }, '200 OK');
+    })->with([
+        'HTTP/1.1 Host localhost' => [
+            "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        ],
+        'HTTP/1.0 no Host header' => [
+            "GET / HTTP/1.0\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with example.com' => [
+            "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with www.example.com' => [
+            "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with example.com and port' => [
+            "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with 192.168.0.1' => [
+            "GET / HTTP/1.1\r\nHost: 192.168.0.1\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with 1.1.1.1' => [
+            "GET / HTTP/1.1\r\nHost: 1.1.1.1\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with 1.1.1.1:8080' => [
+            "GET / HTTP/1.1\r\nHost: 1.1.1.1:8080\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with localhost and port 80' => [
+            "GET / HTTP/1.1\r\nHost: localhost:80\r\n\r\n",
+        ],
+        'HTTP/1.1 Host with localhost and port 65535' => [
+            "GET / HTTP/1.1\r\nHost: localhost:65535\r\n\r\n",
+        ],
     ]);
 
     it('rejects duplicate Transfer-Encoding header lines', function (string $buffer) {

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -139,8 +139,8 @@ describe('HTTP/1.1 header syntax and RFC 7230 field-name (Http::input)', functio
     });
 });
 
-describe('Host header', function () {
-    it('rejects bad Host header uri-host[:port] RFC 9110 Section 7.2', function (string $buffer) {
+describe('Host header uri-host[:port] RFC 9110 Section 7.2', function () {
+    it('rejects bad Host header', function (string $buffer) {
         testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
             expect(Http::input($buffer, $tcpConnection))->toBe(0);
         }, '400 Bad Request');
@@ -171,7 +171,7 @@ describe('Host header', function () {
         ],
     ]);
 
-    it('accepts valid Host header uri-host[:port] RFC 9110 Section 7.2', function (string $buffer) {
+    it('accepts valid Host header', function (string $buffer) {
         /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */
         $tcpConnection = Mockery::spy(TcpConnection::class);
         expect(Http::input($buffer, $tcpConnection))->not->toBe(0);


### PR DESCRIPTION
Add validation for Host header format according to RFC 9110.

EDIT: also fix nullable deprecation in Mockery lib
```
PHP Deprecated:  Mockery::formatArgs(): Implicitly marking parameter $arguments as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/workerman/workerman/vendor/mockery/mockery/library/Mockery.php on line 546
PHP Deprecated:  Mockery::formatObjects(): Implicitly marking parameter $objects as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/workerman/workerman/vendor/mockery/mockery/library/Mockery.php on line 622
```