### PR TITLE
Disabled methods

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -78,6 +78,13 @@ class Http
     protected const HTTP_413 = "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n";
 
     /**
+     * Method Not Allowed.
+     *
+     * @var string
+     */
+    protected const HTTP_405 = "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n";
+
+    /**
      * Request Header Fields Too Large.
      *
      * @var string
@@ -89,6 +96,13 @@ class Http
      */
     
     protected const MAX_HEADER_LENGTH = 16384;
+
+    /**
+     * Disabled methods.
+     *
+     * @var string[]
+     */
+    public static array $disabledMethods = ['TRACE', 'OPTIONS'];
 
     /**
      * Get or set the request class name.
@@ -137,11 +151,17 @@ class Http
         // Validate request line: METHOD SP origin-form SP HTTP/1.x
         $firstLineEnd = strpos($header, "\r\n");
         if (!preg_match(
-            '~^(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH) /[^\x00-\x20\x7f]* (?-i:HTTP)/1\.(?<minor>[0-9])$~',
+            '~^(?-i:GET|POST|OPTIONS|HEAD|DELETE|PUT|PATCH|TRACE) /[^\x00-\x20\x7f]* (?-i:HTTP)/1\.(?<minor>[0-9])$~',
             substr($header, 0, $firstLineEnd),
             $matches
         )) {
             $connection->end(static::HTTP_400, true);
+            return 0;
+        }
+
+        // Check if the method is disabled
+        if (in_array($matches[0], static::$disabledMethods, true)) {
+            $connection->end(static::HTTP_405, true);
             return 0;
         }
 

--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -160,7 +160,7 @@ class Http
         }
 
         // Check if the method is disabled
-        if (in_array($matches[0], static::$disabledMethods, true)) {
+        if (in_array($matches[0], static::$disabledMethods)) {
             $connection->end(static::HTTP_405, true);
             return 0;
         }

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -219,12 +219,19 @@ describe('Disabled Http methods return 405', function () {
             expect(Http::input($buffer, $tcpConnection))->toBe(0);
         }, '405 Method Not Allowed');
     })->with([
-        'OPTIONS' => [
-            "OPTIONS / HTTP/1.1\r\n\r\n",
-        ],
-        'TRACE' => [
-            "TRACE / HTTP/1.1\r\n\r\n",
-        ],
+        'OPTIONS' => ["OPTIONS / HTTP/1.1\r\n\r\n"],
+        'TRACE'   => ["TRACE / HTTP/1.1\r\n\r\n"],
+    ]);
+
+    it('rejects manual method', function (string $buffer) {
+        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
+            Http::$disabledMethods = [...Http::$disabledMethods, 'DELETE', 'POST'];
+            expect(Http::input($buffer, $tcpConnection))->toBe(0);
+        }, '405 Method Not Allowed');
+    })->with([
+        'DELETE' => ["DELETE / HTTP/1.1\r\n\r\n"],
+        'POST'   => ["POST / HTTP/1.1\r\n\r\n"],
+        'TRACE'  => ["TRACE / HTTP/1.1\r\n\r\n"],
     ]);
 });
 

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -225,7 +225,8 @@ describe('Disabled Http methods return 405', function () {
 
     it('rejects manual method', function (string $buffer) {
         testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
-            Http::$disabledMethods = [...Http::$disabledMethods, 'DELETE', 'POST'];
+            Http::$disabledMethods[] = 'DELETE';
+            Http::$disabledMethods[] = 'POST';
             expect(Http::input($buffer, $tcpConnection))->toBe(0);
         }, '405 Method Not Allowed');
     })->with([

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -213,6 +213,21 @@ describe('Host header uri-host[:port] RFC 9110 Section 7.2', function () {
     ]);
 });
 
+describe('Disabled Http methods return 405', function () {
+    it('rejects bad method', function (string $buffer) {
+        testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
+            expect(Http::input($buffer, $tcpConnection))->toBe(0);
+        }, '405 Method Not Allowed');
+    })->with([
+        'Method OPTIONS' => [
+            "OPTIONS * HTTP/1.1\r\n\r\n",
+        ],
+        'Method TRACE' => [
+            "TRACE / HTTP/1.1\r\n\r\n",
+        ],
+    ]);
+});
+
 describe('HTTP/1.0', function () {
     it('accepts minimal GET without Host header', function () {
         /** @var TcpConnection&\Mockery\MockInterface $tcpConnection */

--- a/tests/Unit/Protocols/HttpTest.php
+++ b/tests/Unit/Protocols/HttpTest.php
@@ -214,15 +214,15 @@ describe('Host header uri-host[:port] RFC 9110 Section 7.2', function () {
 });
 
 describe('Disabled Http methods return 405', function () {
-    it('rejects bad method', function (string $buffer) {
+    it('rejects method', function (string $buffer) {
         testWithConnectionEnd(function (TcpConnection $tcpConnection) use ($buffer) {
             expect(Http::input($buffer, $tcpConnection))->toBe(0);
         }, '405 Method Not Allowed');
     })->with([
-        'Method OPTIONS' => [
-            "OPTIONS * HTTP/1.1\r\n\r\n",
+        'OPTIONS' => [
+            "OPTIONS / HTTP/1.1\r\n\r\n",
         ],
-        'Method TRACE' => [
+        'TRACE' => [
             "TRACE / HTTP/1.1\r\n\r\n",
         ],
     ]);


### PR DESCRIPTION
Created Http::$disabledMethods so any developer can enable or disable Http methods.

By default `OPTIONS` and `TRACE` are disabled and return a `405 Method Not Allowed`.
