### PR TITLE
Fix header extraction logic in Http class to account for buffer length

### DIFF
--- a/src/Protocols/Http.php
+++ b/src/Protocols/Http.php
@@ -128,7 +128,7 @@ class Http
             $connection->end(static::HTTP_431, true);
             return 0;
         }
-        $header = isset($buffer[$length]) ? substr($buffer, 0, $length) : $buffer;
+        $header = isset($buffer[$length + 1]) ? substr($buffer, 0, $length) : $buffer;
 
         if ($length <= TcpConnection::MAX_CACHE_STRING_LENGTH && isset($cache[$header])) {
             return $cache[$header];


### PR DESCRIPTION
Before always return the `substr()`, even when it's the end of the buffer.

Before:
`$header = isset($buffer[$length]) ? substr($buffer, 0, $length) : $buffer;`

Now:
`$header = isset($buffer[$length + 1]) ? substr($buffer, 0, $length) : $buffer;`
